### PR TITLE
(Fix #48) ImageChooserBlock resolving to an integer within StreamBlocks

### DIFF
--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -155,10 +155,11 @@ class StreamBlock(StructBlock):
         for field in self.value.stream_data:
             block = self.value.stream_block.child_blocks[field["type"]]
             value = field['value']
-            if issubclass(type(block), block.ChooserBlock):
+            if (
+              issubclass(type(block), wagtail.core.blocks.ChooserBlock)
+              or not issubclass(type(block), blocks.StructBlock)
+            ):
                 value = block.to_python(value)
-            elif not issubclass(type(block), blocks.StructBlock):
-                value = block.to_python(field["value"])
 
             stream_blocks.append(StructBlockItem(field["type"], block, value))
         return stream_blocks

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -137,7 +137,10 @@ class StructBlock(graphene.ObjectType):
         stream_blocks = []
         for name, value in self.value.items():
             block = self.block.child_blocks[name]
-            if issubclass(type(block), blocks.ChooserBlock):
+            if (
+              issubclass(type(block), wagtail.core.blocks.ChooserBlock)
+              and hasattr(value, 'id')
+            ):
                 value = block.to_python(value.id)
             elif not issubclass(type(block), blocks.StreamBlock):
                 value = block.to_python(value)

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -137,7 +137,9 @@ class StructBlock(graphene.ObjectType):
         stream_blocks = []
         for name, value in self.value.items():
             block = self.block.child_blocks[name]
-            if not issubclass(type(block), blocks.StreamBlock):
+            if issubclass(type(block), blocks.ChooserBlock):
+                value = block.to_python(value.id)
+            elif not issubclass(type(block), blocks.StreamBlock):
                 value = block.to_python(value)
 
             stream_blocks.append(StructBlockItem(name, block, value))
@@ -153,7 +155,7 @@ class StreamBlock(StructBlock):
         for field in self.value.stream_data:
             block = self.value.stream_block.child_blocks[field["type"]]
             value = field['value']
-            if issubclass(type(block), wagtail.images.blocks.ImageChooserBlock):
+            if issubclass(type(block), block.ChooserBlock):
                 value = block.to_python(value)
             elif not issubclass(type(block), blocks.StructBlock):
                 value = block.to_python(field["value"])

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -152,10 +152,13 @@ class StreamBlock(StructBlock):
         stream_blocks = []
         for field in self.value.stream_data:
             block = self.value.stream_block.child_blocks[field["type"]]
-            if not issubclass(type(block), blocks.StructBlock):
+            value = field['value']
+            if issubclass(type(block), wagtail.images.blocks.ImageChooserBlock):
+                value = block.to_python(value)
+            elif not issubclass(type(block), blocks.StructBlock):
                 value = block.to_python(field["value"])
 
-            stream_blocks.append(StructBlockItem(field["type"], block, field["value"]))
+            stream_blocks.append(StructBlockItem(field["type"], block, value))
         return stream_blocks
 
 


### PR DESCRIPTION
This PR pipes the correct value for `ImageChooserBlock` through to the `StreamBlock.resolve_blocks` resolver, so that the consumer can access image path information etc.

This fixes #48 which I was also experiencing, where such blocks in StreamBlock would resolve to an integer rather than to the image object.

<img width="408" alt="Screenshot 2020-03-25 at 18 07 09" src="https://user-images.githubusercontent.com/237556/77570316-7ba04300-6ec3-11ea-9e94-2d9c260c92a7.png">
