### PR TITLE
Fix StreamBlock resolution of parent StructBlock

### DIFF
--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -155,10 +155,11 @@ class StreamBlock(StructBlock):
         for field in self.value.stream_data:
             block = self.value.stream_block.child_blocks[field["type"]]
             value = field['value']
-            if issubclass(type(block), block.ChooserBlock):
+            if (
+              issubclass(type(block), wagtail.core.blocks.ChooserBlock)
+              or not issubclass(type(block), blocks.StructBlock)
+            ):
                 value = block.to_python(value)
-            elif not issubclass(type(block), blocks.StructBlock):
-                value = block.to_python(field["value"])
 
             stream_blocks.append(StructBlockItem(field["type"], block, value))
         return stream_blocks

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -137,7 +137,10 @@ class StructBlock(graphene.ObjectType):
         stream_blocks = []
         for name, value in self.value.items():
             block = self.block.child_blocks[name]
-            if issubclass(type(block), blocks.ChooserBlock):
+            if (
+              issubclass(type(block), wagtail.core.blocks.ChooserBlock)
+              and hasattr(value, 'id')
+            ):
                 value = block.to_python(value.id)
             elif not issubclass(type(block), blocks.StreamBlock):
                 value = block.to_python(value)

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -137,7 +137,9 @@ class StructBlock(graphene.ObjectType):
         stream_blocks = []
         for name, value in self.value.items():
             block = self.block.child_blocks[name]
-            if not issubclass(type(block), blocks.StreamBlock):
+            if issubclass(type(block), blocks.ChooserBlock):
+                value = block.to_python(value.id)
+            elif not issubclass(type(block), blocks.StreamBlock):
                 value = block.to_python(value)
 
             stream_blocks.append(StructBlockItem(name, block, value))
@@ -153,7 +155,7 @@ class StreamBlock(StructBlock):
         for field in self.value.stream_data:
             block = self.value.stream_block.child_blocks[field["type"]]
             value = field['value']
-            if issubclass(type(block), wagtail.images.blocks.ImageChooserBlock):
+            if issubclass(type(block), block.ChooserBlock):
                 value = block.to_python(value)
             elif not issubclass(type(block), blocks.StructBlock):
                 value = block.to_python(field["value"])

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -152,10 +152,13 @@ class StreamBlock(StructBlock):
         stream_blocks = []
         for field in self.value.stream_data:
             block = self.value.stream_block.child_blocks[field["type"]]
-            if not issubclass(type(block), blocks.StructBlock):
+            value = field['value']
+            if issubclass(type(block), wagtail.images.blocks.ImageChooserBlock):
+                value = block.to_python(value)
+            elif not issubclass(type(block), blocks.StructBlock):
                 value = block.to_python(field["value"])
 
-            stream_blocks.append(StructBlockItem(field["type"], block, field["value"]))
+            stream_blocks.append(StructBlockItem(field["type"], block, value))
         return stream_blocks
 
 

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -155,16 +155,28 @@ class StreamBlock(StructBlock):
 
     def resolve_blocks(self, info, **kwargs):
         stream_blocks = []
-        for field in self.value.stream_data:
-            block = self.value.stream_block.child_blocks[field["type"]]
+
+        if issubclass(type(self.value), wagtail.core.blocks.stream_block.StreamValue):
+          # self: StreamChild, block: StreamBlock, value: StreamValue
+          stream_data = self.value.stream_data
+          child_blocks = self.value.stream_block.child_blocks
+        else:
+          # This occurs when StreamBlock is child of StructBlock
+          # self: StructBlockItem, block: StreamBlock, value: list
+          stream_data = self.value
+          child_blocks = self.block.child_blocks
+
+        for field in stream_data:
+            block = child_blocks[field["type"]]
             value = field['value']
             if (
               issubclass(type(block), wagtail.core.blocks.ChooserBlock)
               or not issubclass(type(block), blocks.StructBlock)
             ):
-                value = block.to_python(value)
+              value = block.to_python(value)
 
             stream_blocks.append(StructBlockItem(field["type"], block, value))
+
         return stream_blocks
 
 


### PR DESCRIPTION
This PR resolves StreamBlocks whose parents are StructBlocks.

There is likely a more elegant fix that resolves this at a higher level but it works for me right now so I'm posting it here for others who might find it useful. This relies on commits of #54 (the relevant commit for this PR is https://github.com/torchbox/wagtail-grapple/pull/55/commits/74eff2bee81d231c17b852b96afb52b882123cd5) and **does not yet have tests.**

Previously I was getting these errors:
<img width="522" alt="Screenshot 2020-03-26 at 18 57 01" src="https://user-images.githubusercontent.com/237556/77688531-22561380-6f98-11ea-9ed6-b17f06332b51.png">
<img width="389" alt="Screenshot 2020-03-26 at 18 57 09" src="https://user-images.githubusercontent.com/237556/77688532-22eeaa00-6f98-11ea-832a-ccdbaf240b13.png">

I tracked this down to `StreamBlock.resolve_blocks`. See these logs of `self` on `StreamBlock.resolve_blocks` showing how the resolver receives a list.

```
### Parent StructBlock
self.id: a4fce29c-c8ee-4589-97a3-96565cf3b688
type(self): <class 'wagtail.core.blocks.stream_block.StreamValue.StreamChild'>
type(self.block) : <class 'wagtail.core.blocks.stream_block.StreamBlock'>
type(self.value) : <class 'wagtail.core.blocks.stream_block.StreamValue'>

### Child StreamBlock 1
self.id: main_content
type(self): <class 'grapple.types.streamfield.StructBlockItem'>
type(self.block) <class 'wagtail.core.blocks.stream_block.StreamBlock'>
type(self.value) : <class 'list'>

### Child StreamBlock 2
self.id: contextual_content
type(self): <class 'grapple.types.streamfield.StructBlockItem'>
type(self.block) <class 'wagtail.core.blocks.stream_block.StreamBlock'>
type(self.value) : <class 'list'>
```