### PR TITLE
WIP: Add CollectionObjectType to schema + add collections to ImageObjectType

### DIFF
--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -71,8 +71,7 @@ def add_app(app_label: str, prefix: str = ""):
 
     # Add snippet models to model collection.
     for snippet in get_snippet_models():
-        if snippet._meta.app_label == app_label:
-            models.append(snippet)
+        models.append(snippet)
 
     # Create add each model to correct section of registry.
     for model in models:

--- a/grapple/registry.py
+++ b/grapple/registry.py
@@ -9,6 +9,7 @@ class Registry:
     pages = RegistryItem()
     documents = RegistryItem()
     images = RegistryItem()
+    collections = RegistryItem()
     snippets = RegistryItem()
     streamfield_blocks = RegistryItem()
     django_models = RegistryItem()
@@ -19,6 +20,7 @@ class Registry:
         "pages",
         "documents",
         "images",
+        "collections",
         "snippets",
         "django_models",
         "settings",
@@ -33,6 +35,7 @@ class Registry:
         models.update(self.pages)
         models.update(self.documents)
         models.update(self.images)
+        models.update(self.collections)
         models.update(self.snippets)
         models.update(self.django_models)
         models.update(self.settings)
@@ -44,6 +47,7 @@ class Registry:
         models.update(self.pages)
         models.update(self.documents)
         models.update(self.images)
+        models.update(self.collections)
         models.update(self.snippets)
         models.update(self.streamfield_blocks)
         models.update(self.django_models)

--- a/grapple/schema.py
+++ b/grapple/schema.py
@@ -23,6 +23,7 @@ def create_schema():
     from .registry import registry
     from .types.documents import DocumentsQuery
     from .types.images import ImagesQuery
+    from .types.collections import CollectionsQuery
     from .types.pages import PagesQuery, PagesSubscription
     from .types.search import SearchQuery
     from .types.settings import SettingsQuery
@@ -33,6 +34,7 @@ def create_schema():
         graphene.ObjectType,
         PagesQuery(),
         ImagesQuery(),
+        CollectionsQuery(),
         DocumentsQuery(),
         SnippetsQuery(),
         SettingsQuery(),

--- a/grapple/types/collections.py
+++ b/grapple/types/collections.py
@@ -19,13 +19,6 @@ class CollectionObjectType(DjangoObjectType):
     name = graphene.String()
     descendants = graphene.List(lambda: CollectionObjectType)
     ancestors = graphene.List(lambda: CollectionObjectType)
-    contents = graphene.List(lambda: CollectionObjectType)
-
-    def resolve_contents(self, info):
-        return list([
-            hook(self)
-            for hook in hooks.get_hooks("describe_collection_contents")
-        ])
 
     def resolve_descendants(self, info):
         return self.get_descendants()

--- a/grapple/types/collections.py
+++ b/grapple/types/collections.py
@@ -1,0 +1,52 @@
+from wagtail.core.models import Collection
+from wagtail.core import hooks
+from graphene_django.types import DjangoObjectType
+import graphene
+from ..registry import registry
+from ..utils import resolve_queryset
+from .structures import QuerySetList
+
+
+class CollectionObjectType(DjangoObjectType):
+    """
+    Collection type
+    """
+
+    class Meta:
+        model = Collection
+
+    id = graphene.ID()
+    name = graphene.String()
+    descendants = graphene.List(lambda: CollectionObjectType)
+    ancestors = graphene.List(lambda: CollectionObjectType)
+    contents = graphene.List(lambda: CollectionObjectType)
+
+    def resolve_contents(self, info):
+        return list([
+            hook(self)
+            for hook in hooks.get_hooks("describe_collection_contents")
+        ])
+
+    def resolve_descendants(self, info):
+        return self.get_descendants()
+
+    def resolve_ancestors(self, info):
+        return self.get_ancestors()
+
+
+def CollectionsQuery():
+    mdl = Collection
+    mdl_type = registry.collections.get(mdl, CollectionObjectType)
+
+    class Mixin:
+        collections = QuerySetList(mdl_type, enable_search=False)
+        collection_type = graphene.String()
+
+        # Return all collections
+        def resolve_collections(self, info, **kwargs):
+            return resolve_queryset(mdl.objects.all(), info, **kwargs)
+
+        def resolve_collection_type(self, info, **kwargs):
+            return mdl_type
+
+    return Mixin

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -40,7 +40,12 @@ def DocumentsQuery():
 
     class Mixin:
         documents = QuerySetList(
-            graphene.NonNull(model_type), enable_search=True, required=True
+            graphene.NonNull(model_type),
+            enable_search=True,
+            required=True,
+            collection=graphene.Argument(
+                graphene.ID, description="Filter by collection id"
+            ),
         )
 
         # Return all pages, ideally specific.

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -14,6 +14,7 @@ from wagtail.images.models import (
 from ..registry import registry
 from ..utils import resolve_queryset
 from .structures import QuerySetList
+from .collections import CollectionObjectType
 
 
 def get_image_url(cls):
@@ -29,11 +30,12 @@ def get_image_url(cls):
 
 
 class BaseImageObjectType(graphene.ObjectType):
-    width = graphene.Int(required=True)
-    height = graphene.Int(required=True)
-    src = graphene.String(required=True)
-    aspect_ratio = graphene.Float(required=True)
-    sizes = graphene.String(required=True)
+    width = graphene.Int()
+    height = graphene.Int()
+    src = graphene.String()
+    aspect_ratio = graphene.Float()
+    sizes = graphene.String()
+    collection = graphene.Field(lambda: CollectionObjectType)
 
     def resolve_src(self, info):
         """

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -139,7 +139,12 @@ def ImagesQuery():
 
     class Mixin:
         images = QuerySetList(
-            graphene.NonNull(mdl_type), enable_search=True, required=True
+            graphene.NonNull(mdl_type),
+            enable_search=True,
+            required=True,
+            collection=graphene.Argument(
+                graphene.ID, description="Filter by collection id"
+            ),
         )
         image_type = graphene.String(required=True)
 

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -9,7 +9,15 @@ from wagtail.search.backends import get_search_backend
 
 
 def resolve_queryset(
-    qs, info, limit=None, offset=None, search_query=None, id=None, order=None, **kwargs
+    qs,
+    info,
+    limit=None,
+    offset=None,
+    search_query=None,
+    id=None,
+    order=None,
+    collection=None,
+    **kwargs
 ):
     """
     Add limit, offset and search capabilities to the query. This contains
@@ -20,7 +28,7 @@ def resolve_queryset(
     :param limit: Limit number of objects in the QuerySet.
     :type limit: int
     :param id: Filter by the primary key.
-    :type limit: int
+    :type id: int
     :param offset: Omit a number of objects from the beggining of the query set
     :type offset: int
     :param search_query: Using wagtail search exclude objects that do not match
@@ -28,6 +36,8 @@ def resolve_queryset(
     :type search_query: str
     :param order: Use Django ordering format to order the query set.
     :type order: str
+    :param collection: Use Wagtail's collection id to filter images or documents
+    :type collection: int
     """
     offset = int(offset or 0)
 
@@ -53,6 +63,9 @@ def resolve_queryset(
     if limit is not None:
         limit = int(limit)
         qs = qs[offset : limit + offset]
+
+    if collection is not None:
+        qs = qs.filter(collection=collection)
 
     return qs
 


### PR DESCRIPTION
[Wagtail's collections](https://docs.wagtail.io/en/v2.8.1/editor_manual/documents_images_snippets/collections.html) are pretty useful, and I noticed that they were not retrieved by wagtail-grapple by default. 

This is a bit of a work in progress, I took inspiration from `grapple.types.images`, but maybe I got something wrong

This PR could use some help, especially
- [ ] Add tests

Let me know where it can be improved 😉 