### PR TITLE
Update non-nullable GraphQL schema field types

### DIFF
--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -17,10 +17,10 @@ class DocumentObjectType(DjangoObjectType):
         model = WagtailDocument
         exclude_fields = ("tags",)
 
-    id = graphene.ID()
-    title = graphene.String()
-    file = graphene.String()
-    created_at = graphene.DateTime()
+    id = graphene.ID(required=True)
+    title = graphene.String(required=True)
+    file = graphene.String(required=True)
+    created_at = graphene.DateTime(required=True)
     file_size = graphene.Int()
     file_hash = graphene.String()
 
@@ -31,7 +31,7 @@ def DocumentsQuery():
     model_type = registry.documents[mdl]
 
     class Mixin:
-        documents = QuerySetList(model_type, enable_search=True)
+        documents = QuerySetList(graphene.NonNull(model_type), enable_search=True, required=True)
 
         # Return all pages, ideally specific.
         def resolve_documents(self, info, **kwargs):

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -29,11 +29,11 @@ def get_image_url(cls):
 
 
 class BaseImageObjectType(graphene.ObjectType):
-    width = graphene.Int()
-    height = graphene.Int()
-    src = graphene.String()
-    aspect_ratio = graphene.Float()
-    sizes = graphene.String()
+    width = graphene.Int(required=True)
+    height = graphene.Int(required=True)
+    src = graphene.String(required=True)
+    aspect_ratio = graphene.Float(required=True)
+    sizes = graphene.String(required=True)
 
     def resolve_src(self, info):
         """
@@ -52,8 +52,8 @@ class BaseImageObjectType(graphene.ObjectType):
 
 
 class ImageRenditionObjectType(DjangoObjectType, BaseImageObjectType):
-    id = graphene.ID()
-    url = graphene.String()
+    id = graphene.ID(required=True)
+    url = graphene.String(required=True)
 
     class Meta:
         model = WagtailImageRendition
@@ -136,8 +136,8 @@ def ImagesQuery():
     mdl_type = get_image_type()
 
     class Mixin:
-        images = QuerySetList(mdl_type, enable_search=True)
-        image_type = graphene.String()
+        images = QuerySetList(graphene.NonNull(mdl_type), enable_search=True, required=True)
+        image_type = graphene.String(required=True)
 
         # Return all pages, ideally specific.
         def resolve_images(self, info, **kwargs):

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -16,23 +16,23 @@ from .structures import QuerySetList
 class PageInterface(graphene.Interface):
     id = graphene.ID()
     url = graphene.String()
-    url_path = graphene.String()
-    slug = graphene.String()
+    url_path = graphene.String(required=True)
+    slug = graphene.String(required=True)
     depth = graphene.Int()
     page_type = graphene.String()
-    title = graphene.String()
-    seo_title = graphene.String()
+    title = graphene.String(required=True)
+    seo_title = graphene.String(required=True)
     seo_description = graphene.String()
-    show_in_menus = graphene.Boolean()
-    content_type = graphene.String()
+    show_in_menus = graphene.Boolean(required=True)
+    content_type = graphene.String(required=True)
     last_published_at = graphene.DateTime()
     parent = graphene.Field(lambda: PageInterface)
-    children = QuerySetList(lambda: PageInterface, enable_search=True)
-    siblings = QuerySetList(lambda: PageInterface, enable_search=True)
-    next_siblings = QuerySetList(lambda: PageInterface, enable_search=True)
-    previous_siblings = QuerySetList(lambda: PageInterface, enable_search=True)
-    descendants = QuerySetList(lambda: PageInterface, enable_search=True)
-    ancestors = QuerySetList(lambda: PageInterface, enable_search=True)
+    children = QuerySetList(graphene.NonNull(lambda: PageInterface), enable_search=True, required=True)
+    siblings = QuerySetList(graphene.NonNull(lambda: PageInterface), enable_search=True, required=True)
+    next_siblings = QuerySetList(graphene.NonNull(lambda: PageInterface), enable_search=True, required=True)
+    previous_siblings = QuerySetList(graphene.NonNull(lambda: PageInterface), enable_search=True, required=True)
+    descendants = QuerySetList(graphene.NonNull(lambda: PageInterface), enable_search=True, required=True)
+    ancestors = QuerySetList(graphene.NonNull(lambda: PageInterface), enable_search=True, required=True)
 
     def resolve_content_type(self, info: ResolveInfo):
         self.content_type = ContentType.objects.get_for_model(self)
@@ -87,7 +87,7 @@ class PageInterface(graphene.Interface):
             self.get_next_siblings().exclude(pk=self.pk).specific(), info, **kwargs
         )
 
-    def resolve_prev_siblings(self, info, **kwargs):
+    def resolve_previous_siblings(self, info, **kwargs):
         """
         Resolves a list of direct prev siblings of this page. Similar to `resolve_siblings` with sorting.
         Source: https://github.com/wagtail/wagtail/blob/master/wagtail/core/models.py#L1387
@@ -95,6 +95,13 @@ class PageInterface(graphene.Interface):
         return resolve_queryset(
             self.get_prev_siblings().exclude(pk=self.pk).specific(), info, **kwargs
         )
+
+    def resolve_descendants(self, info, **kwargs):
+        """
+        Resolves a list of nodes pointing to the current page’s descendants.
+        Docs: https://docs.wagtail.io/en/stable/reference/pages/model_reference.html#wagtail.core.models.Page.get_descendants
+        """
+        return resolve_queryset(self.get_descendants().specific(), info, **kwargs)
 
     def resolve_ancestors(self, info, **kwargs):
         """
@@ -123,7 +130,7 @@ class Page(DjangoObjectType):
 
 def get_specific_page(id, slug, token, content_type=None):
     """
-    Get a spcecific page, also get preview if token is passed
+    Get a specific page, also get preview if token is passed
     """
     page = None
     try:
@@ -154,7 +161,7 @@ def PagesQuery():
     registry.pages[type(WagtailPage)] = Page
 
     class Mixin:
-        pages = QuerySetList(lambda: PageInterface, enable_search=True)
+        pages = QuerySetList(graphene.NonNull(lambda: PageInterface), enable_search=True, required=True)
         page = graphene.Field(
             PageInterface,
             id=graphene.Int(),

--- a/grapple/types/redirects.py
+++ b/grapple/types/redirects.py
@@ -8,11 +8,11 @@ from .pages import PageInterface
 
 
 class RedirectType(graphene.ObjectType):
-    old_path = graphene.String()
-    old_url = graphene.String()
-    new_url = graphene.String()
+    old_path = graphene.String(required=True)
+    old_url = graphene.String(required=True)
+    new_url = graphene.String(required=True)
     page = graphene.Field(PageInterface)
-    is_permanent = graphene.Boolean()
+    is_permanent = graphene.Boolean(required=True)
 
     # Give old_path with BASE_URL attached.
     def resolve_old_url(self, info, **kwargs):
@@ -32,7 +32,7 @@ class RedirectType(graphene.ObjectType):
 
 
 class RedirectsQuery:
-    redirects = graphene.List(RedirectType)
+    redirects = graphene.List(graphene.NonNull(RedirectType), required=True)
 
     # Return all redirects.
     def resolve_redirects(self, info, **kwargs):

--- a/grapple/types/search.py
+++ b/grapple/types/search.py
@@ -14,7 +14,7 @@ def SearchQuery():
                 types = tuple(registry.class_models.values())
 
         class Mixin:
-            search = graphene.List(Search, query=graphene.String())
+            search = graphene.List(graphene.NonNull(Search), query=graphene.String(), required=True)
 
             # Return just one setting base on name param.
             def resolve_search(self, info, **kwargs):

--- a/grapple/types/settings.py
+++ b/grapple/types/settings.py
@@ -11,7 +11,7 @@ def SettingsQuery():
 
         class Mixin:
             setting = graphene.Field(SettingsObjectType, name=graphene.String())
-            settings = graphene.List(SettingsObjectType)
+            settings = graphene.List(graphene.NonNull(SettingsObjectType), required=True)
 
             # Return just one setting base on name param.
             def resolve_setting(self, info, **kwargs):

--- a/grapple/types/snippets.py
+++ b/grapple/types/snippets.py
@@ -10,7 +10,7 @@ def SnippetsQuery():
                 types = registry.snippets.types
 
         class Mixin:
-            snippets = graphene.List(SnippetObjectType)
+            snippets = graphene.List(graphene.NonNull(SnippetObjectType), required=True)
             # Return all snippets.
 
             def resolve_snippets(self, info, **kwargs):

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -30,9 +30,9 @@ def convert_stream_field(field, registry=None):
 
 class StreamFieldInterface(graphene.Interface):
     id = graphene.String()
-    block_type = graphene.String()
-    field = graphene.String()
-    raw_value = graphene.String()
+    block_type = graphene.String(required=True)
+    field = graphene.String(required=True)
+    raw_value = graphene.String(required=True)
 
     @classmethod
     def resolve_type(cls, instance, info):
@@ -131,7 +131,7 @@ class StructBlock(graphene.ObjectType):
     class Meta:
         interfaces = (StreamFieldInterface,)
 
-    blocks = graphene.List(StreamFieldInterface)
+    blocks = graphene.List(graphene.NonNull(StreamFieldInterface), required=True)
 
     def resolve_blocks(self, info, **kwargs):
         stream_blocks = []
@@ -160,77 +160,77 @@ class StreamBlock(StructBlock):
 
 
 class StreamFieldBlock(graphene.ObjectType):
-    value = graphene.String()
+    value = graphene.String(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class CharBlock(graphene.ObjectType):
-    value = graphene.String()
+    value = graphene.String(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class TextBlock(graphene.ObjectType):
-    value = graphene.String()
+    value = graphene.String(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class EmailBlock(graphene.ObjectType):
-    value = graphene.String()
+    value = graphene.String(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class IntegerBlock(graphene.ObjectType):
-    value = graphene.Int()
+    value = graphene.Int(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class FloatBlock(graphene.ObjectType):
-    value = graphene.Float()
+    value = graphene.Float(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class DecimalBlock(graphene.ObjectType):
-    value = graphene.Float()
+    value = graphene.Float(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class RegexBlock(graphene.ObjectType):
-    value = graphene.String()
+    value = graphene.String(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class URLBlock(graphene.ObjectType):
-    value = graphene.String()
+    value = graphene.String(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class BooleanBlock(graphene.ObjectType):
-    value = graphene.Boolean()
+    value = graphene.Boolean(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class DateBlock(graphene.ObjectType):
-    value = graphene.String(format=graphene.String())
+    value = graphene.String(format=graphene.String(), required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
@@ -253,34 +253,34 @@ class TimeBlock(DateBlock):
 
 
 class RichTextBlock(graphene.ObjectType):
-    value = graphene.String()
+    value = graphene.String(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class RawHTMLBlock(graphene.ObjectType):
-    value = graphene.String()
+    value = graphene.String(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class BlockQuoteBlock(graphene.ObjectType):
-    value = graphene.String()
+    value = graphene.String(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class ChoiceOption(graphene.ObjectType):
-    key = graphene.String()
-    value = graphene.String()
+    key = graphene.String(required=True)
+    value = graphene.String(required=True)
 
 
 class ChoiceBlock(graphene.ObjectType):
-    value = graphene.String()
-    choices = graphene.List(ChoiceOption)
+    value = graphene.String(required=True)
+    choices = graphene.List(graphene.NonNull(ChoiceOption), required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
@@ -300,8 +300,8 @@ def get_media_url(url):
 
 
 class EmbedBlock(graphene.ObjectType):
-    value = graphene.String()
-    url = graphene.String()
+    value = graphene.String(required=True)
+    url = graphene.String(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
@@ -313,14 +313,14 @@ class EmbedBlock(graphene.ObjectType):
 
 
 class StaticBlock(graphene.ObjectType):
-    value = graphene.String()
+    value = graphene.String(required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
 
 
 class ListBlock(graphene.ObjectType):
-    items = graphene.List(StreamFieldInterface)
+    items = graphene.List(graphene.NonNull(StreamFieldInterface), required=True)
 
     class Meta:
         interfaces = (StreamFieldInterface,)
@@ -366,7 +366,7 @@ def register_streamfield_blocks():
     from .images import get_image_type
 
     class PageChooserBlock(graphene.ObjectType):
-        page = graphene.Field(PageInterface)
+        page = graphene.Field(PageInterface, required=True)
 
         class Meta:
             interfaces = (StreamFieldInterface,)
@@ -375,7 +375,7 @@ def register_streamfield_blocks():
             return self.value
 
     class DocumentChooserBlock(graphene.ObjectType):
-        document = graphene.Field(get_document_type())
+        document = graphene.Field(get_document_type(), required=True)
 
         class Meta:
             interfaces = (StreamFieldInterface,)
@@ -384,7 +384,7 @@ def register_streamfield_blocks():
             return self.value
 
     class ImageChooserBlock(graphene.ObjectType):
-        image = graphene.Field(get_image_type())
+        image = graphene.Field(get_image_type(), required=True)
 
         class Meta:
             interfaces = (StreamFieldInterface,)
@@ -393,7 +393,7 @@ def register_streamfield_blocks():
             return self.value
 
     class SnippetChooserBlock(graphene.ObjectType):
-        snippet = graphene.String()
+        snippet = graphene.String(required=True)
 
         class Meta:
             interfaces = (StreamFieldInterface,)


### PR DESCRIPTION
This updates the GraphQL schema to make sure the non-nullable fields are shown correctly.
GraphQL types updated:
- DocumentObjectType
- ImageObjectType
- PageInterface
- RedirectType
- All StreamField blocks (StreamFieldInterface, etc)

GraphQL queries updated:
- documents
- images
- pages
- redirects
- search
- settings
- snippets