### PR TITLE
List Grapple URLs before Wagtail URLs in example project

### DIFF
--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -14,11 +14,11 @@ urlpatterns = [
     url(r"^admin/", include(wagtailadmin_urls)),
     url(r"^documents/", include(wagtaildocs_urls)),
     url(r"^search/$", search_views.search, name="search"),
+    url(r"", include(grapple_urls)),
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in
     # the list:
     url(r"", include(wagtail_urls)),
-    url(r"", include(grapple_urls)),
     # Alternatively, if you want Wagtail pages to be served from a subpath
     # of your site, rather than the site root:
     #    url(r'^pages/', include(wagtail_urls)),


### PR DESCRIPTION
Before, the grapple URLs were loaded after the Wagtail URLs. 
This caused the Wagtail serving mechanism trying to serve the GraphQL endpoint 
and results in 403, because the serving mechanism does not expect POST requests. 

The Grapple URLs are now loaded before the Wagtail URLs. 
This enables the GraphQL endpoint to properly respond to requests.