### PR TITLE
Resolve  correct object for chooser blocks for StreamBlock interface

### DIFF
--- a/example/home/blocks.py
+++ b/example/home/blocks.py
@@ -51,6 +51,14 @@ class VideoBlock(blocks.StructBlock):
     graphql_fields = [GraphQLEmbed("youtube_link")]
 
 
+@register_streamfield_block
+class CarouselBlock(blocks.StreamBlock):
+    text = blocks.CharBlock(classname="full title")
+    image = ImageChooserBlock()
+
+    graphql_fields = [GraphQLString("text"), GraphQLImage("image")]
+
+
 class StreamFieldBlock(blocks.StreamBlock):
     heading = blocks.CharBlock(classname="full title")
     paragraph = blocks.RichTextBlock()
@@ -61,3 +69,4 @@ class StreamFieldBlock(blocks.StreamBlock):
     gallery = ImageGalleryBlock()
     video = VideoBlock()
     objectives = blocks.ListBlock(blocks.CharBlock())
+    carousel = CarouselBlock()

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -135,16 +135,27 @@ class StructBlock(graphene.ObjectType):
 
     def resolve_blocks(self, info, **kwargs):
         stream_blocks = []
-        for name, value in self.value.items():
-            block = self.block.child_blocks[name]
-            if issubclass(type(block), wagtail.core.blocks.ChooserBlock) and hasattr(
-                value, "id"
-            ):
-                value = block.to_python(value.id)
-            elif not issubclass(type(block), blocks.StreamBlock):
+
+        if issubclass(type(self.value), wagtail.core.blocks.stream_block.StreamValue):
+            # self: StreamChild, block: StreamBlock, value: StreamValue
+            stream_data = self.value.stream_data
+            child_blocks = self.value.stream_block.child_blocks
+        else:
+            # This occurs when StreamBlock is child of StructBlock
+            # self: StructBlockItem, block: StreamBlock, value: list
+            stream_data = self.value
+            child_blocks = self.block.child_blocks
+
+        for field in stream_data:
+            block = child_blocks[field["type"]]
+            value = field["value"]
+            if issubclass(
+                type(block), wagtail.core.blocks.ChooserBlock
+            ) or not issubclass(type(block), blocks.StructBlock):
                 value = block.to_python(value)
 
-            stream_blocks.append(StructBlockItem(name, block, value))
+            stream_blocks.append(StructBlockItem(field["type"], block, value))
+
         return stream_blocks
 
 

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -137,7 +137,11 @@ class StructBlock(graphene.ObjectType):
         stream_blocks = []
         for name, value in self.value.items():
             block = self.block.child_blocks[name]
-            if not issubclass(type(block), blocks.StreamBlock):
+            if issubclass(type(block), wagtail.core.blocks.ChooserBlock) and hasattr(
+                value, "id"
+            ):
+                value = block.to_python(value.id)
+            elif not issubclass(type(block), blocks.StreamBlock):
                 value = block.to_python(value)
 
             stream_blocks.append(StructBlockItem(name, block, value))
@@ -152,10 +156,13 @@ class StreamBlock(StructBlock):
         stream_blocks = []
         for field in self.value.stream_data:
             block = self.value.stream_block.child_blocks[field["type"]]
-            if not issubclass(type(block), blocks.StructBlock):
-                value = block.to_python(field["value"])
+            value = field["value"]
+            if issubclass(
+                type(block), wagtail.core.blocks.ChooserBlock
+            ) or not issubclass(type(block), blocks.StructBlock):
+                value = block.to_python(value)
 
-            stream_blocks.append(StructBlockItem(field["type"], block, field["value"]))
+            stream_blocks.append(StructBlockItem(field["type"], block, value))
         return stream_blocks
 
 


### PR DESCRIPTION
This an edited version of #54

> This PR pipes the correct value for ImageChooserBlock through to the StreamBlock.resolve_blocks resolver, so that the consumer can access image path information etc.
> 
> This fixes #48 which I was also experiencing, where such blocks in StreamBlock would resolve to an integer rather than to the image object.