### PR TITLE
Bump supported Wagtail version

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Getting Grapple installed is designed to be as simple as possible!
 ### Prerequisites
 ```
 Django  >= 2.2, <2.3
-wagtail >= 2.5, <2.8
+wagtail >= 2.5, <2.11
 ```
 
 ### Installation
@@ -198,8 +198,8 @@ Contributions are what make the open source community such an amazing place to b
 Wagtail Grapple supports:
 
 - Django 2.2.x
-- Python 3.6 and 3.7
-- Wagtail >= 2.5
+- Python 3.6, 3.7 and 3.8
+- Wagtail >= 2.5, < 2.11
 
 ## License
 

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -1,6 +1,13 @@
-from wagtail.documents.models import Document as WagtailDocument, get_document_model
-from graphene_django.types import DjangoObjectType
 import graphene
+
+from wagtail import VERSION as WAGTAIL_VERSION
+from wagtail.documents.models import Document as WagtailDocument
+from graphene_django.types import DjangoObjectType
+
+if WAGTAIL_VERSION < (2, 9):
+    from wagtail.documents.models import get_document_model
+else:
+    from wagtail.documents import get_document_model
 
 from ..registry import registry
 from ..utils import resolve_queryset

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -1,8 +1,10 @@
 import graphene
 
+from graphene_django.types import DjangoObjectType
+
 from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.documents.models import Document as WagtailDocument
-from graphene_django.types import DjangoObjectType
+
 
 if WAGTAIL_VERSION < (2, 9):
     from wagtail.documents.models import get_document_model

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=2.2,<2.3
-wagtail>=2.5,<2.9
+wagtail>=2.5,<2.11
 graphene-django==2.7.1
 channels==1.1.8
 asgi_redis
@@ -8,5 +8,5 @@ wagtailmedia
 graphql-core==2.2.1
 factory-boy==2.12.0
 wagtail-factories==2.0.0
-django-cors-headers==3.0.2
+django-cors-headers==3.4.0
 wagtail-headless-preview==0.1.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ include_package_data = true
 packages = find:
 install_requires =
     Django>=2.2, <2.3
-    wagtail>=2.5, <2.9
+    wagtail>=2.5, <2.11
     graphene-django==2.7.1
     graphql-core==2.2.1
     channels==1.1.8


### PR DESCRIPTION
Fixes #85

The test have the following warning:
```
RuntimeWarning: Model 'grapple.stubmodel' was already registered. Reloading models is not advised as it can lead to inconsistencies, most notably with related models.
  new_class._meta.apps.register_model(new_class._meta.app_label, new_class)
```

but that was there previously.