### PR TITLE
Django 3.0 compatibility via optional channels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,3 +32,19 @@ jobs:
           rm db.sqlite3
           python manage.py migrate
           python manage.py test
+
+
+  test_channels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install Dependencies
+        run: |
+          pip install -r requirements-channels.txt
+          pip install .
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,4 +47,3 @@ jobs:
         run: |
           pip install -r requirements-channels.txt
           pip install .
-

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ installed_apps = [
 ]
 ```
 
-For GraphQL Subscriptions with Django Channels, run `pip install wagtail_grapple[channels]`  and add 
+For GraphQL Subscriptions with Django Channels, run `pip install wagtail_grapple[channels]`  and add
 `channels` to installed apps:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ This library is an abstraction upon and relies heavily on Graphene & Graphene Dj
 We also use Django Channels and the Potrace image library.
 * [Graphene](https://github.com/graphql-python/graphene)
 * [Graphene Django](https://github.com/graphql-python/graphene)
-* [Django Channels](https://github.com/django/channels)
 * [Potrace](https://github.com/skyrpex/potrace)
+* [Django Channels](https://github.com/django/channels) when installed with `wagtail_grapple[channels]`
 
 
 ## Getting Started
@@ -83,14 +83,15 @@ Getting Grapple installed is designed to be as simple as possible!
 
 ### Prerequisites
 ```
-Django  >= 2.2, <2.3
+Django  >= 2.2, <3.1 (<2.3 if using channels)
 wagtail >= 2.5, <2.11
 ```
 
 ### Installation
-`pip install wagtail_grapple`
 
-<br />
+```bash
+pip install wagtail_grapple
+```
 
 Add the following to the `installed_apps` list in your Wagtail settings file:
 
@@ -104,7 +105,19 @@ installed_apps = [
 ]
 ```
 
-<br />
+For GraphQL Subscriptions with Django Channels, run `pip install wagtail_grapple[channels]`  and add 
+`channels` to installed apps:
+
+```python
+installed_apps = [
+    ...
+    "grapple",
+    "graphene_django",
+    "channels",
+    ...
+]
+```
+
 
 Add the following to the bottom of the same settings file, where each key is the app you want to this library to scan and the value is the prefix you want to give to GraphQL types (you can usually leave this blank):
 
@@ -115,8 +128,6 @@ GRAPPLE_APPS = {
     "home": ""
 }
 ```
-
-<br />
 
 Add the GraphQL URLs to your `urls.py`:
 
@@ -130,10 +141,8 @@ urlpatterns = [
 ]
 ```
 
-<br/>
 Done! Now you can proceed onto configuring your models to generate GraphQL types that adopt their structure :tada:
 _Your GraphQL endpoint is available at http://localhost:8000/graphql/_
-<br/>
 
 ## Usage
 
@@ -197,7 +206,7 @@ Contributions are what make the open source community such an amazing place to b
 
 Wagtail Grapple supports:
 
-- Django 2.2.x
+- Django 2.2.x, 3.0.x
 - Python 3.6, 3.7 and 3.8
 - Wagtail >= 2.5, < 2.11
 

--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -172,6 +172,7 @@ HEADLESS_PREVIEW_LIVE = True
 
 try:
     from channels.asgi import get_channel_layer  # noqa
+
     ASGI_APPLICATION = "asgi.channel_layer"
     CHANNELS_WS_PROTOCOLS = ["graphql-ws"]
 

--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -170,12 +170,17 @@ GRAPPLE_ADD_SEARCH_HIT = True
 HEADLESS_PREVIEW_CLIENT_URLS = {"default": "http://localhost:8001/preview"}
 HEADLESS_PREVIEW_LIVE = True
 
-ASGI_APPLICATION = "asgi.channel_layer"
-CHANNELS_WS_PROTOCOLS = ["graphql-ws"]
-CHANNEL_LAYERS = {
-    "default": {
-        # "BACKEND": "asgi_redis.RedisChannelLayer",
-        "BACKEND": "asgiref.inmemory.ChannelLayer",
-        "ROUTING": "grapple.urls.channel_routing",
+try:
+    from channels.asgi import get_channel_layer  # noqa
+    ASGI_APPLICATION = "asgi.channel_layer"
+    CHANNELS_WS_PROTOCOLS = ["graphql-ws"]
+
+    CHANNEL_LAYERS = {
+        "default": {
+            # "BACKEND": "asgi_redis.RedisChannelLayer",
+            "BACKEND": "asgiref.inmemory.ChannelLayer",
+            "ROUTING": "grapple.urls.channel_routing",
+        }
     }
-}
+except ImportError:
+    pass

--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -53,7 +53,6 @@ INSTALLED_APPS = [
     # GRAPPLE SPECIFIC MODULES
     "grapple",
     "graphene_django",
-    "channels",
 ]
 
 MIDDLEWARE = [
@@ -173,6 +172,7 @@ HEADLESS_PREVIEW_LIVE = True
 try:
     from channels.asgi import get_channel_layer  # noqa
 
+    INSTALLED_APPS += ["channels"]
     ASGI_APPLICATION = "asgi.channel_layer"
     CHANNELS_WS_PROTOCOLS = ["graphql-ws"]
 

--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -13,6 +13,9 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
+
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
@@ -64,7 +67,12 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
-    "wagtail.core.middleware.SiteMiddleware",
+]
+
+if WAGTAIL_VERSION < (2, 9):
+    MIDDLEWARE += ["wagtail.core.middleware.SiteMiddleware"]
+
+MIDDLEWARE += [
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
 ]
 

--- a/grapple/__init__.py
+++ b/grapple/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = "grapple.apps.Grapple"
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"

--- a/grapple/schema.py
+++ b/grapple/schema.py
@@ -24,7 +24,7 @@ def create_schema():
     from .types.documents import DocumentsQuery
     from .types.images import ImagesQuery
     from .types.media import MediaQuery
-    from .types.pages import PagesQuery, PagesSubscription
+    from .types.pages import PagesQuery, has_channels
     from .types.search import SearchQuery
     from .types.settings import SettingsQuery
     from .types.snippets import SnippetsQuery
@@ -44,12 +44,15 @@ def create_schema():
     ):
         pass
 
-    class Subscription(PagesSubscription(), graphene.ObjectType):
-        pass
+    if has_channels:
+        from .types.pages import PagesSubscription
+
+        class Subscription(PagesSubscription(), graphene.ObjectType):
+            pass
 
     return graphene.Schema(
         query=Query,
-        subscription=Subscription,
+        subscription=Subscription if has_channels else None,
         types=list(registry.models.values()),
         auto_camelcase=getattr(settings, "GRAPPLE_AUTO_CAMELCASE", True),
     )

--- a/grapple/templates/grapple/graphiql.html
+++ b/grapple/templates/grapple/graphiql.html
@@ -52,7 +52,8 @@
       }
     }
     var fetcher;
-    if (true) {
+    var supports_subscriptions = {{ supports_subscriptions|lower }};
+    if (supports_subscriptions) {
       var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient('{{subscriptionsEndpoint}}', {
         reconnect: true
       });

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -10,6 +10,7 @@ from graphql.execution.base import ResolveInfo
 
 try:
     from rx.subjects import Subject
+
     has_channels = True
 except ImportError:
     has_channels = False
@@ -212,18 +213,16 @@ if has_channels:
     # Subject to sync Django Signals to Observable
     preview_subject = Subject()
 
-
     @receiver(preview_update)
     def on_updated(sender, token, **kwargs):
         preview_subject.on_next(token)
 
-
     # Subscription Mixin
     def PagesSubscription():
         def preview_observable(id, slug, token, content_type):
-            return preview_subject.filter(lambda previewToken: previewToken == token).map(
-                lambda token: get_specific_page(id, slug, token, content_type)
-            )
+            return preview_subject.filter(
+                lambda previewToken: previewToken == token
+            ).map(lambda token: get_specific_page(id, slug, token, content_type))
 
         class Mixin:
             page = graphene.Field(

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -1,12 +1,18 @@
 import graphene
 from django.contrib.contenttypes.models import ContentType
+from django.dispatch import receiver
+
 from wagtail.core.models import Page as WagtailPage
 from wagtail_headless_preview.signals import preview_update
 from graphene_django.types import DjangoObjectType
 from graphql.error import GraphQLLocatedError
 from graphql.execution.base import ResolveInfo
-from rx.subjects import Subject
-from django.dispatch import receiver
+
+try:
+    from rx.subjects import Subject
+    has_channels = True
+except ImportError:
+    has_channels = False
 
 from ..registry import registry
 from ..utils import resolve_queryset
@@ -202,37 +208,38 @@ def PagesQuery():
     return Mixin
 
 
-# Subject to sync Django Signals to Observable
-preview_subject = Subject()
+if has_channels:
+    # Subject to sync Django Signals to Observable
+    preview_subject = Subject()
 
 
-@receiver(preview_update)
-def on_updated(sender, token, **kwargs):
-    preview_subject.on_next(token)
+    @receiver(preview_update)
+    def on_updated(sender, token, **kwargs):
+        preview_subject.on_next(token)
 
 
-# Subscription Mixin
-def PagesSubscription():
-    def preview_observable(id, slug, token, content_type):
-        return preview_subject.filter(lambda previewToken: previewToken == token).map(
-            lambda token: get_specific_page(id, slug, token, content_type)
-        )
-
-    class Mixin:
-        page = graphene.Field(
-            PageInterface,
-            id=graphene.Int(),
-            slug=graphene.String(),
-            token=graphene.String(),
-            content_type=graphene.String(),
-        )
-
-        def resolve_page(self, info, **kwargs):
-            return preview_observable(
-                id=kwargs.get("id"),
-                slug=kwargs.get("slug"),
-                token=kwargs.get("token"),
-                content_type=kwargs.get("content_type"),
+    # Subscription Mixin
+    def PagesSubscription():
+        def preview_observable(id, slug, token, content_type):
+            return preview_subject.filter(lambda previewToken: previewToken == token).map(
+                lambda token: get_specific_page(id, slug, token, content_type)
             )
 
-    return Mixin
+        class Mixin:
+            page = graphene.Field(
+                PageInterface,
+                id=graphene.Int(),
+                slug=graphene.String(),
+                token=graphene.String(),
+                content_type=graphene.String(),
+            )
+
+            def resolve_page(self, info, **kwargs):
+                return preview_observable(
+                    id=kwargs.get("id"),
+                    slug=kwargs.get("slug"),
+                    token=kwargs.get("token"),
+                    content_type=kwargs.get("content_type"),
+                )
+
+        return Mixin

--- a/grapple/urls.py
+++ b/grapple/urls.py
@@ -38,4 +38,6 @@ if SHOULD_EXPOSE_GRAPHIQL:
 
 if has_channels:
     # Django Channel (v1.x) routing for subscription support
-    channel_routing = [route_class(GraphQLSubscriptionConsumer, path=r"^/subscriptions")]
+    channel_routing = [
+        route_class(GraphQLSubscriptionConsumer, path=r"^/subscriptions")
+    ]

--- a/grapple/urls.py
+++ b/grapple/urls.py
@@ -4,18 +4,25 @@ from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
 
 from graphene_django.views import GraphQLView
-from channels.routing import route_class
-from graphql_ws.django_channels import GraphQLSubscriptionConsumer
+
+try:
+    from channels.routing import route_class
+    from graphql_ws.django_channels import GraphQLSubscriptionConsumer
+
+    has_channels = True
+except ImportError:
+    has_channels = False
 
 
 def graphiql(request):
     graphiql_settings = {
         "REACT_VERSION": "16.13.1",
         "GRAPHIQL_VERSION": "0.17.5",
-        "SUBSCRIPTIONS_TRANSPORT_VERSION": "0.9.16",
-        "subscriptionsEndpoint": "ws://localhost:8000/subscriptions",
         "endpointURL": "/graphql",
     }
+    if has_channels:
+        graphiql_settings["SUBSCRIPTIONS_TRANSPORT_VERSION"] = "0.9.16"
+        graphiql_settings["subscriptionsEndpoint"] = "ws://localhost:8000/subscriptions"
 
     return render(request, "grapple/graphiql.html", graphiql_settings)
 
@@ -29,5 +36,6 @@ urlpatterns = [url(r"^graphql", csrf_exempt(GraphQLView.as_view()))]
 if SHOULD_EXPOSE_GRAPHIQL:
     urlpatterns.append(url(r"^graphiql", graphiql))
 
-# Django Channel (v1.x) routing for subscription support
-channel_routing = [route_class(GraphQLSubscriptionConsumer, path=r"^/subscriptions")]
+if has_channels:
+    # Django Channel (v1.x) routing for subscription support
+    channel_routing = [route_class(GraphQLSubscriptionConsumer, path=r"^/subscriptions")]

--- a/grapple/urls.py
+++ b/grapple/urls.py
@@ -19,6 +19,7 @@ def graphiql(request):
         "REACT_VERSION": "16.13.1",
         "GRAPHIQL_VERSION": "0.17.5",
         "endpointURL": "/graphql",
+        "supports_subscriptions": has_channels,
     }
     if has_channels:
         graphiql_settings["SUBSCRIPTIONS_TRANSPORT_VERSION"] = "0.9.16"

--- a/requirements-channels.txt
+++ b/requirements-channels.txt
@@ -1,5 +1,14 @@
--r requirements.txt
 Django>=2.2,<2.3
+wagtail>=2.5,<2.11
+graphene-django==2.7.1
+wagtailmedia
+graphql-core==2.2.1
+factory-boy==2.12.0
+wagtail-factories==2.0.0
+django-cors-headers==3.4.0
+wagtail-headless-preview==0.1.4
+
+# Channels-specific requirements
 channels==1.1.8
 asgi_redis
 graphql_ws

--- a/requirements-channels.txt
+++ b/requirements-channels.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+Django>=2.2,<2.3
+channels==1.1.8
+asgi_redis
+graphql_ws

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
-Django>=2.2,<2.3
+Django>=2.2,<3.1
 wagtail>=2.5,<2.11
 graphene-django==2.7.1
-channels==1.1.8
-asgi_redis
-graphql_ws
 wagtailmedia
 graphql-core==2.2.1
 factory-boy==2.12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
 
 [options.extras_require]
 channels =
+    Django>=2.2, <2.3
     channels==1.1.8
     asgi_redis
     graphql_ws

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,11 +30,15 @@ setup_requires =
 include_package_data = true
 packages = find:
 install_requires =
-    Django>=2.2, <2.3
+    Django>=2.2, <3.1
     wagtail>=2.5, <2.11
     graphene-django==2.7.1
     graphql-core==2.2.1
+    wagtail-headless-preview
+
+
+[options.extras_require]
+channels =
     channels==1.1.8
     asgi_redis
     graphql_ws
-    wagtail-headless-preview


### PR DESCRIPTION
Attempt to make channels optional to pave the way for Django 3 support

The default `pip install wagtail_grapple` comes without Channels requirements.  To ge it you now need to run `pip install wagtail-grapple[channels]`

Fixes #73