### PR TITLE
Add `url` to `DocumentObjectType`

### DIFF
--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -154,6 +154,7 @@ MEDIA_URL = "/media/"
 
 WAGTAIL_SITE_NAME = "example"
 WAGTAILIMAGES_IMAGE_MODEL = "images.CustomImage"
+WAGTAILDOCS_SERVE_METHOD = "serve_view"
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -94,7 +94,7 @@ class ImagesTest(BaseGrappleTest):
         self.assertEqual(example_img.id, 1)
         self.assertEqual(example_img.title, "Example Image")
 
-    def test_query_image_src(self):
+    def test_query_src_field(self):
         query = """
         {
             images {
@@ -222,6 +222,23 @@ class DocumentsTest(BaseGrappleTest):
         self.assertEquals(
             executed["data"]["documents"][0]["fileSize"],
             self.example_document.file_size,
+        )
+
+    def test_query_src_field(self):
+        query = """
+        {
+            documents {
+                id
+                src
+            }
+        }
+        """
+
+        executed = self.client.execute(query)
+
+        self.assertEquals(
+            executed["data"]["documents"][0]["src"],
+            "http://localhost:8000" + self.example_document.file.url,
         )
 
     def tearDown(self):

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -83,8 +83,10 @@ class DocumentsTest(BaseGrappleTest):
         )
         self.example_document.full_clean()
         self.example_document.save()
+        self.example_document.get_file_hash()
+        self.example_document.get_file_size()
 
-    def test_example_document_in_wagtail(self):
+    def test_propteries_on_example_document_in_wagtail(self):
         example_doc = self.document_model.objects.first()
 
         self.assertEqual(example_doc.id, 1)
@@ -93,6 +95,9 @@ class DocumentsTest(BaseGrappleTest):
         example_doc.file.seek(0)
 
         self.assertEqual(example_doc.file.readline(), b"Hello world!")
+
+        self.assertNotEqual(example_doc.file_hash, "")
+        self.assertNotEqual(example_doc.file_size, None)
 
     def test_minimal_documents_query(self):
         query = """
@@ -131,6 +136,40 @@ class DocumentsTest(BaseGrappleTest):
         self.assertEquals(
             executed["data"]["documents"][0]["file"],
             self.example_document.file.name,
+        )
+
+    def test_file_hash_field(self):
+        query = """
+        {
+            documents {
+                id
+                fileHash
+            }
+        }
+        """
+
+        executed = self.client.execute(query)
+
+        self.assertEquals(
+            executed["data"]["documents"][0]["fileHash"],
+            self.example_document.file_hash,
+        )
+
+    def test_file_size_field(self):
+        query = """
+        {
+            documents {
+                id
+                fileSize
+            }
+        }
+        """
+
+        executed = self.client.execute(query)
+
+        self.assertEquals(
+            executed["data"]["documents"][0]["fileSize"],
+            self.example_document.file_size,
         )
 
     def tearDown(self):

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -3,7 +3,6 @@ import os
 from collections import OrderedDict
 from pydoc import locate
 
-import django
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
@@ -224,7 +223,7 @@ class DocumentsTest(BaseGrappleTest):
             self.example_document.file_size,
         )
 
-    def test_query_src_field(self):
+    def test_query_src_field_with_default_document_serve_method(self):
         query = """
         {
             documents {
@@ -236,10 +235,30 @@ class DocumentsTest(BaseGrappleTest):
 
         executed = self.client.execute(query)
 
-        self.assertEquals(
+        self.assertEqual(
+            executed["data"]["documents"][0]["src"],
+            "http://localhost:8000" + self.example_document.url,
+        )
+
+    def test_query_src_field_with_direct_document_serve_method(self):
+        serve_method_at_test_start = settings.WAGTAILDOCS_SERVE_METHOD
+        settings.WAGTAILDOCS_SERVE_METHOD = "direct"
+        query = """
+        {
+            documents {
+                id
+                src
+            }
+        }
+        """
+
+        executed = self.client.execute(query)
+
+        self.assertEqual(
             executed["data"]["documents"][0]["src"],
             "http://localhost:8000" + self.example_document.file.url,
         )
+        settings.WAGTAILDOCS_SERVE_METHOD = serve_method_at_test_start
 
     def tearDown(self):
         self.example_document.file.delete()

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -212,12 +212,12 @@ class DocumentsTest(BaseGrappleTest):
             self.example_document.file_size,
         )
 
-    def test_query_src_field_with_default_document_serve_method(self):
+    def test_query_url_field_with_default_document_serve_method(self):
         query = """
         {
             documents {
                 id
-                src
+                url
             }
         }
         """
@@ -225,18 +225,18 @@ class DocumentsTest(BaseGrappleTest):
         executed = self.client.execute(query)
 
         self.assertEqual(
-            executed["data"]["documents"][0]["src"],
+            executed["data"]["documents"][0]["url"],
             "http://localhost:8000" + self.example_document.url,
         )
 
-    def test_query_src_field_with_direct_document_serve_method(self):
+    def test_query_url_field_with_direct_document_serve_method(self):
         serve_method_at_test_start = settings.WAGTAILDOCS_SERVE_METHOD
         settings.WAGTAILDOCS_SERVE_METHOD = "direct"
         query = """
         {
             documents {
                 id
-                src
+                url
             }
         }
         """
@@ -244,7 +244,7 @@ class DocumentsTest(BaseGrappleTest):
         executed = self.client.execute(query)
 
         self.assertEqual(
-            executed["data"]["documents"][0]["src"],
+            executed["data"]["documents"][0]["url"],
             "http://localhost:8000" + self.example_document.file.url,
         )
         settings.WAGTAILDOCS_SERVE_METHOD = serve_method_at_test_start

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -76,6 +76,8 @@ class DocumentsTest(BaseGrappleTest):
     def setUp(self):
         super().setUp()
         self.document_model = get_document_model()
+        self.assertEqual(self.document_model.objects.all().count(), 0)
+
         uploaded_file = SimpleUploadedFile("example.txt", b"Hello world!")
         self.example_document = self.document_model(
             title="Example File",
@@ -85,6 +87,7 @@ class DocumentsTest(BaseGrappleTest):
         self.example_document.save()
         self.example_document.get_file_hash()
         self.example_document.get_file_size()
+        self.assertEqual(self.document_model.objects.all().count(), 1)
 
     def test_propteries_on_example_document_in_wagtail(self):
         example_doc = self.document_model.objects.first()

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -80,9 +80,7 @@ class ImagesTest(BaseGrappleTest):
         super().setUp()
         self.image_model = get_image_model()
         self.assertEqual(self.image_model.objects.all().count(), 0)
-        self.example_image = wagtail_factories.ImageFactory(
-            title="Example Image",
-        )
+        self.example_image = wagtail_factories.ImageFactory(title="Example Image")
         self.example_image.full_clean()
         self.example_image.save()
         self.assertEqual(self.image_model.objects.all().count(), 1)
@@ -105,10 +103,7 @@ class ImagesTest(BaseGrappleTest):
 
         executed = self.client.execute(query)
 
-        self.assertEquals(
-            executed["data"]["images"][0]["id"],
-            "1",
-        )
+        self.assertEquals(executed["data"]["images"][0]["id"], "1")
         self.assertEquals(
             executed["data"]["images"][0]["src"],
             "http://localhost:8000" + self.example_image.file.url,
@@ -128,8 +123,7 @@ class DocumentsTest(BaseGrappleTest):
 
         uploaded_file = SimpleUploadedFile("example.txt", b"Hello world!")
         self.example_document = self.document_model(
-            title="Example File",
-            file=uploaded_file,
+            title="Example File", file=uploaded_file
         )
         self.example_document.full_clean()
         self.example_document.save()
@@ -163,13 +157,9 @@ class DocumentsTest(BaseGrappleTest):
 
         documents = self.document_model.objects.all()
 
+        self.assertEquals(len(executed["data"]["documents"]), documents.count())
         self.assertEquals(
-            len(executed["data"]["documents"]),
-            documents.count(),
-        )
-        self.assertEquals(
-            executed["data"]["documents"][0]["id"],
-            str(self.example_document.id),
+            executed["data"]["documents"][0]["id"], str(self.example_document.id)
         )
 
     def test_query_file_field(self):
@@ -185,8 +175,7 @@ class DocumentsTest(BaseGrappleTest):
         executed = self.client.execute(query)
 
         self.assertEquals(
-            executed["data"]["documents"][0]["file"],
-            self.example_document.file.name,
+            executed["data"]["documents"][0]["file"], self.example_document.file.name
         )
 
     def test_query_file_hash_field(self):

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -138,7 +138,7 @@ class DocumentsTest(BaseGrappleTest):
         self.example_document.get_file_size()
         self.assertEqual(self.document_model.objects.all().count(), 1)
 
-    def test_propteries_on_saved_example_document(self):
+    def test_properties_on_saved_example_document(self):
         example_doc = self.document_model.objects.first()
 
         self.assertEqual(example_doc.id, 1)
@@ -151,7 +151,7 @@ class DocumentsTest(BaseGrappleTest):
         self.assertNotEqual(example_doc.file_hash, "")
         self.assertNotEqual(example_doc.file_size, None)
 
-    def test_minimal_documents_query(self):
+    def test_query_documents_id(self):
         query = """
         {
             documents {
@@ -173,7 +173,7 @@ class DocumentsTest(BaseGrappleTest):
             str(self.example_document.id),
         )
 
-    def test_file_field(self):
+    def test_query_file_field(self):
         query = """
         {
             documents {
@@ -190,7 +190,7 @@ class DocumentsTest(BaseGrappleTest):
             self.example_document.file.name,
         )
 
-    def test_file_hash_field(self):
+    def test_query_file_hash_field(self):
         query = """
         {
             documents {
@@ -207,7 +207,7 @@ class DocumentsTest(BaseGrappleTest):
             self.example_document.file_hash,
         )
 
-    def test_file_size_field(self):
+    def test_query_file_size_field(self):
         query = """
         {
             documents {

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -44,9 +44,9 @@ class DocumentObjectType(DjangoObjectType):
     created_at = graphene.DateTime(required=True)
     file_size = graphene.Int()
     file_hash = graphene.String()
-    src = graphene.String(required=True)
+    url = graphene.String(required=True)
 
-    def resolve_src(self, info):
+    def resolve_url(self, info):
         """
         Get url of the document.
         """

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -1,5 +1,6 @@
 import graphene
 
+from django.conf import settings
 from graphene_django.types import DjangoObjectType
 
 from wagtail import VERSION as WAGTAIL_VERSION
@@ -13,6 +14,18 @@ else:
 from ..registry import registry
 from ..utils import resolve_queryset
 from .structures import QuerySetList
+
+
+def get_document_url(cls):
+    url = ""
+    if hasattr(cls, "url"):
+        url = cls.url
+    else:
+        url = cls.file.url
+
+    if url[0] == "/":
+        return settings.BASE_URL + url
+    return url
 
 
 class DocumentObjectType(DjangoObjectType):
@@ -31,7 +44,13 @@ class DocumentObjectType(DjangoObjectType):
     created_at = graphene.DateTime(required=True)
     file_size = graphene.Int()
     file_hash = graphene.String()
+    src = graphene.String(required=True)
 
+    def resolve_src(self, info):
+        """
+        Get url of the document.
+        """
+        return get_document_url(self)
 
 def DocumentsQuery():
     registry.documents[WagtailDocument] = DocumentObjectType

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -52,6 +52,7 @@ class DocumentObjectType(DjangoObjectType):
         """
         return get_document_url(self)
 
+
 def DocumentsQuery():
     registry.documents[WagtailDocument] = DocumentObjectType
     mdl = get_document_model()


### PR DESCRIPTION
As described in #94, it is currently necessary to construct the URL where a document can be loaded from the backend on the client side.
This is error prone and creates unnecessary coupling between the frontend and backend configuration (or code). 

The `ImageObjectType` on the other hand already provides a `src` field which will return a fully qualified URL under which the image can be reached. 

This PR implements the `src` field on the `DocumentObjectType`. The implementation is pretty much copied over from the `BaseImageObjectType`. 

A small set of tests have been added to ensure the functionality of the new field. Because I could not find other tests that directly test the queries for `images` and `documents` I have added the tests in `example/tests/test_grapple.py`.  A test for the `src` field on the `ImageObjectType` has been added in the same file for reference. 


Let me know what you think, and if any adjustments are necessary.


Closes #94 


