### PR TITLE
Match document file handling to media file handling

### DIFF
--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -1,5 +1,6 @@
 import graphene
 
+from django.conf import settings
 from graphene_django.types import DjangoObjectType
 
 from wagtail import VERSION as WAGTAIL_VERSION
@@ -31,6 +32,11 @@ class DocumentObjectType(DjangoObjectType):
     created_at = graphene.DateTime(required=True)
     file_size = graphene.Int()
     file_hash = graphene.String()
+
+    def resolve_file(self, info, **kwargs):
+        if self.file.url[0] == "/":
+            return settings.BASE_URL + self.file.url
+        return self.file.url
 
 
 def DocumentsQuery():


### PR DESCRIPTION
Fixes #94.

Currently the these graphQL types return the following values:
**Image:**
   file: `original_images/_myfile.png`
   src: `http://localhost:8000/media/original_images/_myfile.png`
**Media**: 
   file: `http://localhost:8000/media/media/myfile.MP4`
**Document**:
   file: `documents/myfile.pdf`

It was a bit difficult to determine the correct course of action, given the contradictions between the existing api. I made the assumption that images should remain as they are and that documents should match medias handling, since media has a file but no source. 

These proposed changes update the file resolver of document to match medias implementation, which looks like this:

**Document**
    file: `http://localhost:8000/media/documents/myfile.pdf`

If the maintainers of the project would prefer to add src to document and media I'd be happy to make that adjustment instead.

As well please note that in the same manner that media resolved its file, I utilize `self.file.url`. Another url could have been used via `self.url` which would have yielded `http://localhost:8000/documents/1/my.pdf`.  It was unclear which one would be ideal, so I deferred to the the media resolver's example. I did notice that the image object tries both...