### PR TITLE
Update supported versions

### DIFF
--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -1,7 +1,12 @@
 import os
+import sys
 import wagtail_factories
 
-from collections import OrderedDict
+if sys.version_info >= (3, 7):
+    from builtins import dict as dict_type
+else:
+    from collections import OrderedDict as dict_type
+
 from pydoc import locate
 
 from django.conf import settings
@@ -40,9 +45,9 @@ class PagesTest(BaseGrappleTest):
 
         executed = self.client.execute(query)
 
-        self.assertEquals(type(executed["data"]), OrderedDict)
+        self.assertEquals(type(executed["data"]), dict_type)
         self.assertEquals(type(executed["data"]["pages"]), list)
-        self.assertEquals(type(executed["data"]["pages"][0]), OrderedDict)
+        self.assertEquals(type(executed["data"]["pages"][0]), dict_type)
 
         pages_data = executed["data"]["pages"]
         self.assertEquals(pages_data[0]["contentType"], "wagtailcore.Page")
@@ -73,9 +78,9 @@ class DisableAutoCamelCaseTest(TestCase):
 
         executed = self.client.execute(query)
 
-        self.assertEquals(type(executed["data"]), OrderedDict)
+        self.assertEquals(type(executed["data"]), dict_type)
         self.assertEquals(type(executed["data"]["pages"]), list)
-        self.assertEquals(type(executed["data"]["pages"][0]), OrderedDict)
+        self.assertEquals(type(executed["data"]["pages"][0]), dict_type)
         self.assertEquals(type(executed["data"]["pages"][0]["title"]), str)
         self.assertEquals(type(executed["data"]["pages"][0]["url_path"]), str)
 

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -111,7 +111,6 @@ def get_fields_and_properties(cls):
     """
     fields = [field.name for field in cls._meta.get_fields(include_parents=False)]
 
-    properties = []
     try:
         properties = [
             method[0]

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -242,7 +242,20 @@ def load_type_fields():
                     interfaces = (interface,) if interface is not None else tuple()
 
                 type_meta = {"Meta": Meta, "id": graphene.ID(), "name": type_name}
-                exclude_fields = get_fields_and_properties(cls)
+
+                exclude_fields = []
+                for field in get_fields_and_properties(cls):
+                    # Filter our any fields that are defined on the interface of base type to prevent the
+                    # 'Excluding the custom field "<field>" on DjangoObjectType "<cls>" has no effect.
+                    # Either remove the custom field or remove the field from the "exclude" list.' warning
+                    if (
+                        field == "id"
+                        or hasattr(interface, field)
+                        or hasattr(base_type, field)
+                    ):
+                        continue
+
+                    exclude_fields.append(field)
 
                 # Add any custom fields to node if they are defined.
                 methods = {}

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -23,7 +23,7 @@ class DocumentObjectType(DjangoObjectType):
 
     class Meta:
         model = WagtailDocument
-        exclude_fields = ("tags",)
+        exclude = ("tags",)
 
     id = graphene.ID(required=True)
     title = graphene.String(required=True)

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -75,7 +75,7 @@ class ImageObjectType(DjangoObjectType, BaseImageObjectType):
 
     class Meta:
         model = WagtailImage
-        exclude_fields = ("tags",)
+        exclude = ("tags",)
 
     def resolve_rendition(self, info, **kwargs):
         """

--- a/grapple/types/media.py
+++ b/grapple/types/media.py
@@ -12,7 +12,7 @@ from .structures import QuerySetList
 class MediaObjectType(DjangoObjectType):
     class Meta:
         model = Media
-        exclude_fields = ("tags",)
+        exclude = ("tags",)
 
     url = graphene.String(required=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Django>=2.2,<3.1
+Django>=2.2,<3.2
 wagtail>=2.5,<2.11
-graphene-django==2.7.1
 wagtailmedia
-graphql-core==2.2.1
+graphql-core>=2.2.1,<3
+graphene-django>=2.7.1, <2.14.0
 factory-boy==2.12.0
 wagtail-factories==2.0.0
 django-cors-headers==3.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,10 @@ setup_requires =
 include_package_data = true
 packages = find:
 install_requires =
-    Django>=2.2, <3.1
+    Django>=2.2, <3.2
     wagtail>=2.5, <2.11
-    graphene-django==2.7.1
-    graphql-core==2.2.1
+    graphene-django>=2.7.1, <2.14.0
+    graphql-core>=2.2.1, <3
     wagtail-headless-preview
 
 


### PR DESCRIPTION
Django <= 3.1
django-graphene < 2.14.0

Need to fix

```
graphene_django/types.py:110: UserWarning: Excluding the custom field "url" on DjangoObjectType "HomePage" has no effect. Either remove the custom field or remove the field from the "exclude" list.
graphene_django/types.py:110: UserWarning: Excluding the custom field "url" on DjangoObjectType "AuthorPage" has no effect. Either remove the custom field or remove the field from the "exclude" list.
graphene_django/types.py:110: UserWarning: Excluding the custom field "url" on DjangoObjectType "BlogPage" has no effect. Either remove the custom field or remove the field from the "exclude" list.
graphene_django/types.py:110: UserWarning: Excluding the custom field "id" on DjangoObjectType "Person" has no effect. Either remove the custom field or remove the field from the "exclude" list.
graphene_django/types.py:110: UserWarning: Excluding the custom field "id" on DjangoObjectType "Advert" has no effect. Either remove the custom field or remove the field from the "exclude" list.
graphene_django/types.py:110: UserWarning: Excluding the custom field "id" on DjangoObjectType "BlogPageRelatedLink" has no effect. Either remove the custom field or remove the field from the "exclude" list.
graphene_django/types.py:110: UserWarning: Excluding the custom field "id" on DjangoObjectType "Author" has no effect. Either remove the custom field or remove the field from the "exclude" list.
graphene_django/types.py:110: UserWarning: Excluding the custom field "id" on DjangoObjectType "SocialMediaSettings" has no effect. Either remove the custom field or remove the field from the "exclude" list.
graphene_django/types.py:110: UserWarning: Excluding the custom field "id" on DjangoObjectType "CustomImage" has no effect. Either remove the custom field or remove the field from the "exclude" list.
graphene_django/types.py:110: UserWarning: Excluding the custom field "width" on DjangoObjectType "CustomImage" has no effect. Either remove the custom field or remove the field from the "exclude" list.
graphene_django/types.py:110: UserWarning: Excluding the custom field "height" on DjangoObjectType "CustomImage" has no effect. Either remove the custom field or remove the field from the "exclude" list.
```

which is a result of https://github.com/graphql-python/graphene-django/pull/873

tl;dr these are of the result of https://github.com/GrappleGQL/wagtail-grapple/blob/master/grapple/actions.py#L246 -- `get_fields_and_properties()` will return all fields and properties, which include "id", "pk" for Page subclasses (defined as custom in PageInterface), "url", "width" and "height" for Images (defined in BaseImageObjectType)