### PR TITLE
Use url instead of urlPath in redirections

### DIFF
--- a/grapple/types/redirects.py
+++ b/grapple/types/redirects.py
@@ -23,7 +23,7 @@ class RedirectType(graphene.ObjectType):
         if self.redirect_page is None:
             return self.link
 
-        return self.redirect_page.url_path
+        return self.redirect_page.url
 
     # Return the page that's being redirected to, if at all.
     def resolve_page(self, info, **kwargs):


### PR DESCRIPTION
When using redirects, let's assume you have your homepage's slug set on `/home` if you add redirections from `/blog` to your homepage (or any homepage's children), the redirection will be `/home/[slug]` instead of `/[slug]`

This fixes it. 