### PR TITLE
Add collections types

### DIFF
--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -90,7 +90,8 @@ def add_app(app_label: str, prefix: str = ""):
 
     # Add snippet models to model collection.
     for snippet in get_snippet_models():
-        models.append(snippet)
+        if snippet._meta.app_label == app_label:
+            models.append(snippet)
 
     # Create add each model to correct section of registry.
     for model in models:

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -90,8 +90,7 @@ def add_app(app_label: str, prefix: str = ""):
 
     # Add snippet models to model collection.
     for snippet in get_snippet_models():
-        if snippet._meta.app_label == app_label:
-            models.append(snippet)
+        models.append(snippet)
 
     # Create add each model to correct section of registry.
     for model in models:

--- a/grapple/registry.py
+++ b/grapple/registry.py
@@ -10,6 +10,7 @@ class Registry:
     documents = RegistryItem()
     images = RegistryItem()
     media = RegistryItem()
+    collections = RegistryItem()
     snippets = RegistryItem()
     streamfield_blocks = RegistryItem()
     django_models = RegistryItem()
@@ -21,6 +22,7 @@ class Registry:
         "documents",
         "images",
         "media",
+        "collections",
         "snippets",
         "django_models",
         "settings",
@@ -35,6 +37,7 @@ class Registry:
         models.update(self.pages)
         models.update(self.documents)
         models.update(self.images)
+        models.update(self.collections)
         models.update(self.snippets)
         models.update(self.django_models)
         models.update(self.settings)
@@ -46,6 +49,7 @@ class Registry:
         models.update(self.pages)
         models.update(self.documents)
         models.update(self.images)
+        models.update(self.collections)
         models.update(self.snippets)
         models.update(self.streamfield_blocks)
         models.update(self.django_models)

--- a/grapple/types/collections.py
+++ b/grapple/types/collections.py
@@ -23,7 +23,7 @@ class CollectionObjectType(DjangoObjectType):
     def resolve_descendants(self, info, **kwargs):
         return self.get_descendants()
 
-    def resolve_ancestors(self, info):
+    def resolve_ancestors(self, info, **kwargs):
         return self.get_ancestors()
 
 
@@ -32,8 +32,8 @@ def CollectionsQuery():
     mdl_type = registry.collections.get(mdl, CollectionObjectType)
 
     class Mixin:
-        collections = QuerySetList(mdl_type, enable_search=False)
-        collection_type = graphene.String()
+        collections = QuerySetList(mdl_type, enable_search=False, required=True)
+        collection_type = graphene.String(required=True)
 
         # Return all collections
         def resolve_collections(self, info, **kwargs):

--- a/grapple/types/collections.py
+++ b/grapple/types/collections.py
@@ -19,13 +19,6 @@ class CollectionObjectType(DjangoObjectType):
     name = graphene.String()
     descendants = graphene.List(lambda: CollectionObjectType)
     ancestors = graphene.List(lambda: CollectionObjectType)
-    contents = graphene.List(lambda: CollectionObjectType)
-
-    def resolve_contents(self, info):
-        return list([
-            hook(self)
-            for hook in hooks.get_hooks("describe_collection_contents")
-        ])
 
     def resolve_descendants(self, info):
         return self.get_descendants()

--- a/grapple/types/collections.py
+++ b/grapple/types/collections.py
@@ -15,12 +15,12 @@ class CollectionObjectType(DjangoObjectType):
     class Meta:
         model = Collection
 
-    id = graphene.ID()
-    name = graphene.String()
-    descendants = graphene.List(lambda: CollectionObjectType)
-    ancestors = graphene.List(lambda: CollectionObjectType)
+    id = graphene.ID(required=True)
+    name = graphene.String(required=True)
+    descendants = graphene.List(lambda: CollectionObjectType, required=True)
+    ancestors = graphene.List(lambda: CollectionObjectType, required=True)
 
-    def resolve_descendants(self, info):
+    def resolve_descendants(self, info, **kwargs):
         return self.get_descendants()
 
     def resolve_ancestors(self, info):

--- a/grapple/types/collections.py
+++ b/grapple/types/collections.py
@@ -1,0 +1,52 @@
+from wagtail.core.models import Collection
+from wagtail.core import hooks
+from graphene_django.types import DjangoObjectType
+import graphene
+from ..registry import registry
+from ..utils import resolve_queryset
+from .structures import QuerySetList
+
+
+class CollectionObjectType(DjangoObjectType):
+    """
+    Collection type
+    """
+
+    class Meta:
+        model = Collection
+
+    id = graphene.ID()
+    name = graphene.String()
+    descendants = graphene.List(lambda: CollectionObjectType)
+    ancestors = graphene.List(lambda: CollectionObjectType)
+    contents = graphene.List(lambda: CollectionObjectType)
+
+    def resolve_contents(self, info):
+        return list([
+            hook(self)
+            for hook in hooks.get_hooks("describe_collection_contents")
+        ])
+
+    def resolve_descendants(self, info):
+        return self.get_descendants()
+
+    def resolve_ancestors(self, info):
+        return self.get_ancestors()
+
+
+def CollectionsQuery():
+    mdl = Collection
+    mdl_type = registry.collections.get(mdl, CollectionObjectType)
+
+    class Mixin:
+        collections = QuerySetList(mdl_type, enable_search=False)
+        collection_type = graphene.String()
+
+        # Return all collections
+        def resolve_collections(self, info, **kwargs):
+            return resolve_queryset(mdl.objects.all(), info, **kwargs)
+
+        def resolve_collection_type(self, info, **kwargs):
+            return mdl_type
+
+    return Mixin

--- a/grapple/types/collections.py
+++ b/grapple/types/collections.py
@@ -1,6 +1,6 @@
 import graphene
 
-from graphene_django.types import DjangoObjectType 
+from graphene_django.types import DjangoObjectType
 from wagtail.core.models import Collection
 
 from ..registry import registry

--- a/grapple/types/collections.py
+++ b/grapple/types/collections.py
@@ -1,7 +1,8 @@
-from wagtail.core.models import Collection
-from wagtail.core import hooks
-from graphene_django.types import DjangoObjectType
 import graphene
+
+from graphene_django.types import DjangoObjectType 
+from wagtail.core.models import Collection
+
 from ..registry import registry
 from ..utils import resolve_queryset
 from .structures import QuerySetList

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -12,6 +12,7 @@ else:
 
 from ..registry import registry
 from ..utils import get_media_item_url, resolve_queryset
+from .collections import CollectionObjectType
 from .structures import QuerySetList
 
 
@@ -32,6 +33,7 @@ class DocumentObjectType(DjangoObjectType):
     file_size = graphene.Int()
     file_hash = graphene.String()
     url = graphene.String(required=True)
+    collection = graphene.Field(lambda: CollectionObjectType, required=True)
 
     def resolve_url(self, info, **kwargs):
         """

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -48,7 +48,12 @@ def DocumentsQuery():
     class Mixin:
         document = graphene.Field(model_type, id=graphene.ID())
         documents = QuerySetList(
-            graphene.NonNull(model_type), enable_search=True, required=True
+            graphene.NonNull(model_type),
+            enable_search=True,
+            required=True,
+            collection=graphene.Argument(
+                graphene.ID, description="Filter by collection id"
+            ),
         )
 
         # Return one document.

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -10,6 +10,7 @@ from wagtail.images.models import (
 from ..registry import registry
 from ..utils import resolve_queryset, get_media_item_url
 from .structures import QuerySetList
+from .collections import CollectionObjectType
 
 
 class BaseImageObjectType(graphene.ObjectType):
@@ -20,6 +21,7 @@ class BaseImageObjectType(graphene.ObjectType):
     url = graphene.String(required=True)
     aspect_ratio = graphene.Float(required=True)
     sizes = graphene.String(required=True)
+    collection = graphene.Field(lambda: CollectionObjectType)
 
     def resolve_url(self, info, **kwargs):
         """

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -9,8 +9,8 @@ from wagtail.images.models import (
 
 from ..registry import registry
 from ..utils import resolve_queryset, get_media_item_url
-from .structures import QuerySetList
 from .collections import CollectionObjectType
+from .structures import QuerySetList
 
 
 class BaseImageObjectType(graphene.ObjectType):

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -133,7 +133,12 @@ def ImagesQuery():
     class Mixin:
         image = graphene.Field(mdl_type, id=graphene.ID())
         images = QuerySetList(
-            graphene.NonNull(mdl_type), enable_search=True, required=True
+            graphene.NonNull(mdl_type),
+            enable_search=True,
+            required=True,
+            collection=graphene.Argument(
+                graphene.ID, description="Filter by collection id"
+            ),
         )
         image_type = graphene.String(required=True)
 

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -73,6 +73,7 @@ class ImageObjectType(DjangoObjectType, BaseImageObjectType):
         webpquality=graphene.Int(),
     )
     src_set = graphene.String(sizes=graphene.List(graphene.Int))
+    tags = graphene.List(graphene.String))
 
     class Meta:
         model = WagtailImage
@@ -119,6 +120,16 @@ class ImageObjectType(DjangoObjectType, BaseImageObjectType):
             pass
 
         return ""
+
+    def resolve_tags(self, info, **kwargs):
+        """
+        Generate list of tags
+        """
+        try:
+            if self.tags.all().count > 0:
+                self.tags.all().join(", ")
+        except:
+            return list()
 
 
 def get_image_type():

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -73,7 +73,6 @@ class ImageObjectType(DjangoObjectType, BaseImageObjectType):
         webpquality=graphene.Int(),
     )
     src_set = graphene.String(sizes=graphene.List(graphene.Int))
-    tags = graphene.List(graphene.String)
 
     class Meta:
         model = WagtailImage
@@ -120,16 +119,6 @@ class ImageObjectType(DjangoObjectType, BaseImageObjectType):
             pass
 
         return ""
-
-    def resolve_tags(self, info, **kwargs):
-        """
-        Generate list of tags
-        """
-        try:
-            if self.tags.all().count > 0:
-                self.tags.all().join(", ")
-        except:
-            return list()
 
 
 def get_image_type():

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -73,7 +73,7 @@ class ImageObjectType(DjangoObjectType, BaseImageObjectType):
         webpquality=graphene.Int(),
     )
     src_set = graphene.String(sizes=graphene.List(graphene.Int))
-    tags = graphene.List(graphene.String))
+    tags = graphene.List(graphene.String)
 
     class Meta:
         model = WagtailImage

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -21,7 +21,7 @@ class BaseImageObjectType(graphene.ObjectType):
     url = graphene.String(required=True)
     aspect_ratio = graphene.Float(required=True)
     sizes = graphene.String(required=True)
-    collection = graphene.Field(lambda: CollectionObjectType)
+    collection = graphene.Field(lambda: CollectionObjectType, required=True)
 
     def resolve_url(self, info, **kwargs):
         """

--- a/grapple/types/media.py
+++ b/grapple/types/media.py
@@ -6,6 +6,7 @@ from wagtailmedia.models import Media, get_media_model
 
 from ..registry import registry
 from ..utils import get_media_item_url, resolve_queryset
+from .collections import CollectionObjectType
 from .structures import QuerySetList
 
 
@@ -15,6 +16,7 @@ class MediaObjectType(DjangoObjectType):
         exclude = ("tags",)
 
     url = graphene.String(required=True)
+    collection = graphene.Field(lambda: CollectionObjectType, required=True)
 
     def resolve_url(self, info, **kwargs):
         """

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -12,7 +12,15 @@ from .types.structures import BasePaginatedType, PaginationType
 
 
 def resolve_queryset(
-    qs, info, limit=None, offset=None, search_query=None, id=None, order=None, **kwargs
+    qs,
+    info,
+    limit=None,
+    offset=None,
+    search_query=None,
+    id=None,
+    order=None,
+    collection=None,
+    **kwargs
 ):
     """
     Add limit, offset and search capabilities to the query. This contains
@@ -31,6 +39,8 @@ def resolve_queryset(
     :type search_query: str
     :param order: Order the query set using the Django QuerySet order_by format.
     :type order: str
+    :param collection: Use Wagtail's collection id to filter images or documents
+    :type collection: int
     """
     offset = int(offset or 0)
 
@@ -56,6 +66,9 @@ def resolve_queryset(
     if limit is not None:
         limit = int(limit)
         qs = qs[offset : limit + offset]
+
+    if collection is not None:
+        qs = qs.filter(collection=collection)
 
     return qs
 

--- a/grapple/wagtail_hooks.py
+++ b/grapple/wagtail_hooks.py
@@ -2,6 +2,7 @@ from graphene import ObjectType
 from wagtail.core import hooks
 
 from .registry import registry
+from .types.collections import CollectionsQuery
 from .types.documents import DocumentsQuery
 from .types.images import ImagesQuery
 from .types.pages import PagesQuery
@@ -25,6 +26,7 @@ def register_schema_query(query_mixins):
         SettingsQuery(),
         SearchQuery(),
         TagsQuery(),
+        CollectionsQuery()
         RedirectsQuery,
     ]
 

--- a/grapple/wagtail_hooks.py
+++ b/grapple/wagtail_hooks.py
@@ -26,7 +26,7 @@ def register_schema_query(query_mixins):
         SettingsQuery(),
         SearchQuery(),
         TagsQuery(),
-        CollectionsQuery()
+        CollectionsQuery(),
         RedirectsQuery,
     ]
 


### PR DESCRIPTION
[Wagtail's collections](https://docs.wagtail.io/en/v2.8.1/editor_manual/documents_images_snippets/collections.html) are pretty useful, and I noticed that they were not retrieved by wagtail-grapple by default. 

This is a bit of a work in progress, I took inspiration from `grapple.types.images`, but maybe I got something wrong

This PR could use some help, especially
- [ ] Add tests

Let me know where it can be improved 😉 