### PR TITLE
register_singular_query_field decorator

### DIFF
--- a/docs/general-usage/decorators.rst
+++ b/docs/general-usage/decorators.rst
@@ -268,3 +268,55 @@ instead of the default:
         items: [Advert]
         pagination: PaginationType
     }
+
+
+@register_singular_query_field
+-------------------------------
+.. module:: grapple.helpers
+.. class:: register_singular_query_field(field_name, query_params=None, required=False)
+
+Returns the first item of the given type using the ``Model`` ordering.
+You can expose any Django model by decorating it with ``@register_singular_query_field``. This is especially useful
+when you have Wagtail Pages with ``max_count`` of one(`Ref: Wagtail documentation <https://docs.wagtail.io/en/stable/reference/pages/model_reference.html#wagtail.core.models.Page.max_count>`_),
+thus there is no need to query by id.
+
+::
+
+    from grapple.helpers import register_singular_query_field
+
+    @register_singular_query_field('first_advert')
+    class Advert(models.Model):
+        url = models.URLField(null=True, blank=True)
+        text = models.CharField(max_length=255)
+
+        panels = [FieldPanel("url"), FieldPanel("text")]
+
+        graphql_fields = [GraphQLString("url"), GraphQLString("text")]
+
+        def __str__(self):
+            return self.text
+
+
+and then use it in your queries:
+
+::
+
+    {
+        # Get the first advert
+        firstAdvert {
+            url
+            text
+        }
+    }
+
+If you have multiple items, you could change the order:
+
+::
+
+    {
+        # Get the first advert
+        firstAdvert(order: "-id") {
+            url
+            text
+        }
+    }

--- a/example/home/models.py
+++ b/example/home/models.py
@@ -15,7 +15,11 @@ from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail_headless_preview.models import HeadlessPreviewMixin
 from wagtailmedia.edit_handlers import MediaChooserPanel
 
-from grapple.helpers import register_query_field, register_paginated_query_field
+from grapple.helpers import (
+    register_query_field,
+    register_paginated_query_field,
+    register_singular_query_field,
+)
 from grapple.utils import resolve_paginated_queryset
 from grapple.models import (
     GraphQLString,
@@ -44,6 +48,7 @@ class AuthorPage(Page):
     graphql_fields = [GraphQLString("name")]
 
 
+@register_singular_query_field("first_post")
 @register_paginated_query_field("blog_page")
 class BlogPage(HeadlessPreviewMixin, Page):
     date = models.DateField("Post date")

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
 from django.utils.safestring import SafeText
-from wagtail.core.blocks import BoundBlock, StreamValue, StructValue
+from wagtail.core.blocks import StreamValue
 from wagtail.core.rich_text import RichText
 from wagtail.embeds.blocks import EmbedValue
 

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -551,3 +551,33 @@ class BlogTest(BaseGrappleTest):
                 buttons = query_blocks[0]["buttons"]
                 self.assertEquals(buttons[0]["buttonText"], "btn")
                 self.assertEquals(buttons[0]["buttonLink"], "https://www.graphql.com/")
+
+    def test_singular_blog_page_query(self):
+        def query():
+            return """
+        {
+            firstPost {
+                id
+            }
+        }
+        """
+
+        # add a new blog post
+        another_post = BlogPageFactory()
+        results = self.client.execute(query())
+
+        self.assertTrue("firstPost" in results["data"])
+        self.assertEqual(int(results["data"]["firstPost"]["id"]), self.blog_page.id)
+
+        results = self.client.execute(
+            """
+            {
+                firstPost(order: "-id") {
+                    id
+                }
+            }
+            """
+        )
+
+        self.assertTrue("firstPost" in results["data"])
+        self.assertEqual(int(results["data"]["firstPost"]["id"]), another_post.id)

--- a/grapple/helpers.py
+++ b/grapple/helpers.py
@@ -218,15 +218,21 @@ def register_paginated_query_field(
 def register_singular_query_field(field_name, query_params=None, required=False):
     def inner(cls):
         field_type = lambda: registry.models[cls]
-        field_query_params = query_params or {
-            "token": graphene.Argument(
-                graphene.String, description=ugettext_lazy("The preview token.")
-            ),
-            "order": graphene.Argument(
-                graphene.String,
-                description=ugettext_lazy("Use the Django QuerySet order_by format."),
-            ),
-        }
+        field_query_params = query_params
+
+        if field_query_params is None:
+            field_query_params = {
+                "order": graphene.Argument(
+                    graphene.String,
+                    description=ugettext_lazy(
+                        "Use the Django QuerySet order_by format."
+                    ),
+                ),
+            }
+            if issubclass(cls, Page):
+                field_query_params["token"] = graphene.Argument(
+                    graphene.String, description=ugettext_lazy("The preview token.")
+                )
 
         def Mixin():
             # Generic methods to get all and query one model instance.

--- a/grapple/helpers.py
+++ b/grapple/helpers.py
@@ -51,11 +51,17 @@ def register_query_field(
 
     def inner(cls):
         field_type = lambda: registry.models[cls]
-        field_query_params = query_params or {
-            "id": graphene.Int(),
-            "slug": graphene.String(),
-            "token": graphene.String(),
-        }
+        field_query_params = query_params
+        if field_query_params is None:
+            field_query_params = {"id": graphene.Int()}
+
+            if issubclass(cls, Page):
+                field_query_params["slug"] = graphene.Argument(
+                    graphene.String, description=ugettext_lazy("The page slug.")
+                )
+                field_query_params["token"] = graphene.Argument(
+                    graphene.String, description=ugettext_lazy("The preview token.")
+                )
 
         def Mixin():
             # Generic methods to get all and query one model instance.
@@ -141,11 +147,17 @@ def register_paginated_query_field(
 
     def inner(cls):
         field_type = lambda: registry.models[cls]
-        field_query_params = query_params or {
-            "id": graphene.Int(),
-            "slug": graphene.String(),
-            "token": graphene.String(),
-        }
+        field_query_params = query_params
+        if field_query_params is None:
+            field_query_params = {"id": graphene.Int()}
+
+            if issubclass(cls, Page):
+                field_query_params["slug"] = graphene.Argument(
+                    graphene.String, description=ugettext_lazy("The page slug.")
+                )
+                field_query_params["token"] = graphene.Argument(
+                    graphene.String, description=ugettext_lazy("The preview token.")
+                )
 
         def Mixin():
             # Generic methods to get all and query one model instance.

--- a/grapple/helpers.py
+++ b/grapple/helpers.py
@@ -213,3 +213,61 @@ def register_paginated_query_field(
         return cls
 
     return inner
+
+
+def register_singular_query_field(field_name, query_params=None, required=False):
+    def inner(cls):
+        field_type = lambda: registry.models[cls]
+        field_query_params = query_params or {
+            "token": graphene.Argument(
+                graphene.String, description=ugettext_lazy("The preview token.")
+            ),
+            "order": graphene.Argument(
+                graphene.String,
+                description=ugettext_lazy("Use the Django QuerySet order_by format."),
+            ),
+        }
+
+        def Mixin():
+            # Generic methods to get all and query one model instance.
+            def resolve_singular(self, _, info, **kwargs):
+                try:
+                    # If is a Page then only query live/public pages.
+                    if issubclass(cls, Page):
+                        if "token" in kwargs and hasattr(
+                            cls, "get_page_from_preview_token"
+                        ):
+                            return cls.get_page_from_preview_token(kwargs["token"])
+
+                        qs = cls.objects.live().public()
+                        if "order" in kwargs:
+                            qs = qs.order_by(kwargs.pop("order"))
+                        return qs.filter(**kwargs).first()
+
+                    return cls.objects.first()
+                except:
+                    return None
+
+            # Create schema and add resolve methods
+            schema = type(cls.__name__ + "Query", (), {})
+
+            singular_field_type = field_type
+            if required:
+                singular_field_type = graphene.NonNull(field_type)
+
+            setattr(
+                schema,
+                field_name,
+                graphene.Field(singular_field_type, **field_query_params),
+            )
+
+            setattr(
+                schema, "resolve_" + field_name, MethodType(resolve_singular, schema)
+            )
+            return schema
+
+        # Send schema to Grapple schema.
+        register_graphql_schema(Mixin())
+        return cls
+
+    return inner

--- a/grapple/helpers.py
+++ b/grapple/helpers.py
@@ -2,6 +2,7 @@ import graphene
 import inspect
 from types import MethodType
 
+from django.utils.translation import ugettext_lazy
 from wagtail.core.models import Page
 
 from .registry import registry

--- a/grapple/helpers.py
+++ b/grapple/helpers.py
@@ -232,6 +232,10 @@ def register_singular_query_field(field_name, query_params=None, required=False)
             # Generic methods to get all and query one model instance.
             def resolve_singular(self, _, info, **kwargs):
                 try:
+                    qs = cls.objects
+                    if "order" in kwargs:
+                        qs = qs.order_by(kwargs.pop("order"))
+
                     # If is a Page then only query live/public pages.
                     if issubclass(cls, Page):
                         if "token" in kwargs and hasattr(
@@ -239,12 +243,9 @@ def register_singular_query_field(field_name, query_params=None, required=False)
                         ):
                             return cls.get_page_from_preview_token(kwargs["token"])
 
-                        qs = cls.objects.live().public()
-                        if "order" in kwargs:
-                            qs = qs.order_by(kwargs.pop("order"))
-                        return qs.filter(**kwargs).first()
+                        return qs.live().public().filter(**kwargs).first()
 
-                    return cls.objects.first()
+                    return cls.filter(**kwargs).first()
                 except:
                     return None
 

--- a/grapple/types/structures.py
+++ b/grapple/types/structures.py
@@ -77,7 +77,7 @@ class QuerySetList(graphene.List):
         # Enable ordering of the queryset
         if enable_order is True and "order" not in kwargs:
             kwargs["order"] = graphene.Argument(
-                graphene.String, description=_("Use Django ordering format.")
+                graphene.String, description=_("Use the Django queryset order format.")
             )
 
         # If type is provided as a lazy value (e.g. using lambda), then
@@ -187,7 +187,7 @@ def PaginatedQuerySet(of_type, type_class, **kwargs):
     # Enable ordering of the queryset
     if enable_order is True and "order" not in kwargs:
         kwargs["order"] = graphene.Argument(
-            graphene.String, description=_("Use Django ordering format.")
+            graphene.String, description=_("Use the Django QuerySet order_by format.")
         )
 
     # If type is provided as a lazy value (e.g. using lambda), then

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -18,18 +18,18 @@ def resolve_queryset(
     Add limit, offset and search capabilities to the query. This contains
     argument names used by
     :class:`~grapple.types.structures.QuerySetList`.
-    :param qs: Query set to be modified.
-    :param info: Graphene's info object.
+    :param qs: The query set to be modified.
+    :param info: The Graphene info object.
     :param limit: Limit number of objects in the QuerySet.
     :type limit: int
     :param id: Filter by the primary key.
     :type id: int
-    :param offset: Omit a number of objects from the beggining of the query set
+    :param offset: Omit a number of objects from the beginning of the query set
     :type offset: int
-    :param search_query: Using wagtail search exclude objects that do not match
+    :param search_query: Using Wagtail search, exclude objects that do not match
                          the search query.
     :type search_query: str
-    :param order: Use Django ordering format to order the query set.
+    :param order: Order the query set using the Django QuerySet order_by format.
     :type order: str
     """
     offset = int(offset or 0)
@@ -100,18 +100,18 @@ def resolve_paginated_queryset(
     Add page, per_page and search capabilities to the query. This contains
     argument names used by
     :function:`~grapple.types.structures.PaginatedQuerySet`.
-    :param qs: Query set to be modified.
-    :param info: Graphene's info object.
+    :param qs: The query set to be modified.
+    :param info: The Graphene info object.
     :param page: Page of resulting objects to return from the QuerySet.
     :type page: int
     :param id: Filter by the primary key.
     :type id: int
     :param per_page: The maximum number of items to include on a page.
     :type per_page: int
-    :param search_query: Using wagtail search exclude objects that do not match
+    :param search_query: Using Wagtail search, exclude objects that do not match
                          the search query.
     :type search_query: str
-    :param order: Use Django ordering format to order the query set.
+    :param order: Order the query set using the Django QuerySet order_by format.
     :type order: str
     """
     per_page = int(per_page or 10)


### PR DESCRIPTION
This PR adds a `@register_singular_query_field` decorator that allows one to pull the first item of a particular type.
This is especially useful when you have a Wagtail Page with `max_num = 1`

e.g. 

```python
from wagtail.core.models import Page


@register_singular_query_field("the_page")
class ThePage(Page):
    max_count = 1
```

allows you to query:

```graphql
{
   thePage {
        title
   }
}
```

to get your page, without having to worry about its id