### PR TITLE
Add embed data for StreamField Embed blocks

### DIFF
--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -72,9 +72,7 @@ MIDDLEWARE = [
 if WAGTAIL_VERSION < (2, 9):
     MIDDLEWARE += ["wagtail.core.middleware.SiteMiddleware"]
 
-MIDDLEWARE += [
-    "wagtail.contrib.redirects.middleware.RedirectMiddleware",
-]
+MIDDLEWARE += ["wagtail.contrib.redirects.middleware.RedirectMiddleware"]
 
 ROOT_URLCONF = "example.urls"
 

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -124,7 +124,7 @@ class ImagesTest(BaseGrappleTest):
             "http://localhost:8000" + self.example_image.file.url,
         )
         self.assertEquals(
-            executed["data"]["images"][0]["url"], executed["data"]["images"][0]["src"],
+            executed["data"]["images"][0]["url"], executed["data"]["images"][0]["src"]
         )
 
     def tearDown(self):

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -1,4 +1,3 @@
-import json
 import graphene
 import wagtail
 import inspect
@@ -10,10 +9,10 @@ from django.conf import settings
 from django.template.loader import render_to_string
 from graphene.types import Scalar
 from graphene_django.converter import convert_django_field
-from wagtail.core.blocks import StructValue
 from wagtail.core.fields import StreamField
 from wagtail.core.rich_text import expand_db_html
 from wagtail.core import blocks
+from wagtail.embeds.blocks import EmbedValue
 from wagtail.embeds.embeds import get_embed
 from wagtail.embeds.exceptions import EmbedException
 
@@ -66,7 +65,7 @@ class StreamFieldInterface(graphene.Interface):
         return self.block.name
 
     def resolve_raw_value(self, info, **kwargs):
-        if isinstance(self, StructValue):
+        if isinstance(self, blocks.StructValue):
             # This is the value for a nested StructBlock defined via GraphQLStreamfield
             return serialize_struct_obj(self)
         if isinstance(self.value, dict):
@@ -355,8 +354,8 @@ class EmbedBlock(graphene.ObjectType):
         return get_media_url(get_embed_url(self))
 
     def resolve_raw_value(self, info, **kwargs):
-        if isinstance(self, wagtail.EmbedValue):
-            return serialize_struct_obj(self)
+        if isinstance(self, EmbedValue):
+            return self
         return StreamFieldInterface.resolve_raw_value(info, **kwargs)
 
     def resolve_embed(self, info, **kwargs):


### PR DESCRIPTION
adds `embed` and `rawEmbed` properties

example query:
```graphql
{
  blogPage(id: 5) {
    id
    body {
      ... on VideoBlock {
        youtubeLink {
          url
          embed
          rawEmbed
        }
      }
    }
  }
}
```

and response:

```json
{
  "data": {
    "blogPage": {
      "id": "5",
      "body": [
        {
          "youtubeLink": {
            "url": "https://www.youtube.com/watch?v=_U79Wc965vw",
            "embed": "<iframe width=\"480\" height=\"270\" src=\"https://www.youtube.com/embed/_U79Wc965vw?feature=oembed\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen></iframe>",
            "rawEmbed": "{\"title\": \"Wagtail Space 2018\", \"type\": \"video\", \"thumbnail_url\": \"https://i.ytimg.com/vi/_U79Wc965vw/hqdefault.jpg\", \"width\": 480, \"height\": 270, \"html\": \"<iframe width=\\\"480\\\" height=\\\"270\\\" src=\\\"https://www.youtube.com/embed/_U79Wc965vw?feature=oembed\\\" frameborder=\\\"0\\\" allow=\\\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\\\" allowfullscreen></iframe>\"}"
          }
        }
      ]
    }
  }
}
```