### PR TITLE
Add webpquality support for renditions

### DIFF
--- a/docs/general-usage/graphql-types.rst
+++ b/docs/general-usage/graphql-types.rst
@@ -130,6 +130,7 @@ need for Gatsby Image features to work (see Handy Fragments page for more info):
         format: String
         bgcolor: String
         jpegquality: Int
+        webpquality: Int
     ): ImageRenditionObjectType
 
 

--- a/example/images/models.py
+++ b/example/images/models.py
@@ -8,10 +8,10 @@ from grapple.models import GraphQLString, GraphQLInt, GraphQLImage
 class CustomImage(AbstractImage):
     admin_form_fields = Image.admin_form_fields
 
-    def custom_image_property(self):
+    def custom_image_property(self, info, **kwargs):
         return "Image Model!"
 
-    graphql_fields = (GraphQLString("custom_image_property"),)
+    graphql_fields = (GraphQLString("custom_image_property", required=True),)
 
 
 class CustomImageRendition(AbstractRendition):
@@ -22,15 +22,15 @@ class CustomImageRendition(AbstractRendition):
     class Meta:
         unique_together = (("image", "filter_spec", "focal_point_key"),)
 
-    def custom_rendition_property(self):
+    def custom_rendition_property(self, info, **kwargs):
         return "Rendition Model!"
 
     graphql_fields = (
-        GraphQLString("custom_rendition_property"),
-        GraphQLInt("id"),
-        GraphQLString("url"),
-        GraphQLString("width"),
-        GraphQLString("height"),
-        GraphQLImage("image"),
-        GraphQLString("file"),
+        GraphQLString("custom_rendition_property", required=True),
+        GraphQLInt("id", required=True),
+        GraphQLString("url", required=True),
+        GraphQLString("width", required=True),
+        GraphQLString("height", required=True),
+        GraphQLImage("image", required=True),
+        GraphQLString("file", required=True),
     )

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -46,11 +46,20 @@ def DocumentsQuery():
     model_type = registry.documents[mdl]
 
     class Mixin:
+        document = graphene.Field(model_type, id=graphene.ID())
         documents = QuerySetList(
             graphene.NonNull(model_type), enable_search=True, required=True
         )
 
-        # Return all pages, ideally specific.
+        # Return one document.
+        def resolve_document(self, info, **kwargs):
+            id = kwargs.get("id")
+            try:
+                return mdl.objects.get(pk=id)
+            except BaseException:
+                return None
+
+        # Return all documents.
         def resolve_documents(self, info, **kwargs):
             return resolve_queryset(mdl.objects.all(), info, **kwargs)
 

--- a/grapple/types/documents.py
+++ b/grapple/types/documents.py
@@ -33,7 +33,7 @@ class DocumentObjectType(DjangoObjectType):
     file_hash = graphene.String()
     url = graphene.String(required=True)
 
-    def resolve_url(self, info):
+    def resolve_url(self, info, **kwargs):
         """
         Get document file url.
         """
@@ -52,8 +52,7 @@ def DocumentsQuery():
         )
 
         # Return one document.
-        def resolve_document(self, info, **kwargs):
-            id = kwargs.get("id")
+        def resolve_document(self, info, id, **kwargs):
             try:
                 return mdl.objects.get(pk=id)
             except BaseException:

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -131,12 +131,21 @@ def ImagesQuery():
     mdl_type = get_image_type()
 
     class Mixin:
+        image = graphene.Field(mdl_type, id=graphene.ID())
         images = QuerySetList(
             graphene.NonNull(mdl_type), enable_search=True, required=True
         )
         image_type = graphene.String(required=True)
 
-        # Return all pages, ideally specific.
+        # Return one image.
+        def resolve_image(self, info, **kwargs):
+            id = kwargs.get("id")
+            try:
+                return mdl.objects.get(pk=id)
+            except BaseException:
+                return None
+
+        # Return all images.
         def resolve_images(self, info, **kwargs):
             return resolve_queryset(mdl.objects.all(), info, **kwargs)
 

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -70,6 +70,7 @@ class ImageObjectType(DjangoObjectType, BaseImageObjectType):
         format=graphene.String(),
         bgcolor=graphene.String(),
         jpegquality=graphene.Int(),
+        webpquality=graphene.Int(),
     )
     src_set = graphene.String(sizes=graphene.List(graphene.Int))
 

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -13,6 +13,7 @@ from .structures import QuerySetList
 
 
 class BaseImageObjectType(graphene.ObjectType):
+    id = graphene.ID(required=True)
     width = graphene.Int(required=True)
     height = graphene.Int(required=True)
     src = graphene.String(required=True, deprecation_reason="Use the `url` attribute")
@@ -20,13 +21,13 @@ class BaseImageObjectType(graphene.ObjectType):
     aspect_ratio = graphene.Float(required=True)
     sizes = graphene.String(required=True)
 
-    def resolve_url(self, info):
+    def resolve_url(self, info, **kwargs):
         """
         Get the uploaded image url.
         """
         return get_media_item_url(self)
 
-    def resolve_src(self, info):
+    def resolve_src(self, info, **kwargs):
         """
         Deprecated. Use the `url` attribute.
         """
@@ -38,14 +39,11 @@ class BaseImageObjectType(graphene.ObjectType):
         """
         return self.width / self.height
 
-    def resolve_sizes(self, info):
+    def resolve_sizes(self, info, **kwargs):
         return "(max-width: {}px) 100vw, {}px".format(self.width, self.width)
 
 
 class ImageRenditionObjectType(DjangoObjectType, BaseImageObjectType):
-    id = graphene.ID(required=True)
-    url = graphene.String(required=True)
-
     class Meta:
         model = WagtailImageRendition
 
@@ -138,8 +136,7 @@ def ImagesQuery():
         image_type = graphene.String(required=True)
 
         # Return one image.
-        def resolve_image(self, info, **kwargs):
-            id = kwargs.get("id")
+        def resolve_image(self, info, id, **kwargs):
             try:
                 return mdl.objects.get(pk=id)
             except BaseException:

--- a/grapple/types/media.py
+++ b/grapple/types/media.py
@@ -16,7 +16,7 @@ class MediaObjectType(DjangoObjectType):
 
     url = graphene.String(required=True)
 
-    def resolve_url(self, info):
+    def resolve_url(self, info, **kwargs):
         """
         Get Media file url.
         """

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -6,7 +6,6 @@ from wagtail.core.models import Page as WagtailPage, Site
 from wagtail_headless_preview.signals import preview_update
 from graphene_django.types import DjangoObjectType
 from graphql.error import GraphQLLocatedError
-from graphql.execution.base import ResolveInfo
 
 try:
     from channels.routing import route_class
@@ -54,7 +53,7 @@ class PageInterface(graphene.Interface):
     )
 
     @classmethod
-    def resolve_type(cls, instance, info: ResolveInfo):
+    def resolve_type(cls, instance, info, **kwargs):
         """
         If model has a custom Graphene Node type in registry then use it,
         otherwise use base page type.
@@ -65,7 +64,7 @@ class PageInterface(graphene.Interface):
         else:
             return Page
 
-    def resolve_content_type(self, info: ResolveInfo):
+    def resolve_content_type(self, info, **kwargs):
         self.content_type = ContentType.objects.get_for_model(self)
         return (
             self.content_type.app_label + "." + self.content_type.model_class().__name__
@@ -144,7 +143,7 @@ class PageInterface(graphene.Interface):
             self.get_ancestors().live().public().specific(), info, **kwargs
         )
 
-    def resolve_seo_title(self, info):
+    def resolve_seo_title(self, info, **kwargs):
         """
         Get page's SEO title. Fallback to a normal page's title if absent.
         """

--- a/grapple/types/streamfield.py
+++ b/grapple/types/streamfield.py
@@ -283,7 +283,7 @@ class RichTextBlock(graphene.ObjectType):
     class Meta:
         interfaces = (StreamFieldInterface,)
 
-    def resolve_value(self, value):
+    def resolve_value(self, info, **kwargs):
         # Allow custom markup for RichText
         return render_to_string(
             "wagtailcore/richtext.html", {"html": expand_db_html(self.value.source)}

--- a/grapple/types/tags.py
+++ b/grapple/types/tags.py
@@ -18,10 +18,10 @@ class TagObjectType(graphene.ObjectType):
     tag_id = graphene.ID(name="id", required=True)
     name = graphene.String(required=True)
 
-    def resolve_tag_id(self, info):
+    def resolve_tag_id(self, info, **kwargs):
         return self.id
 
-    def resolve_name(self, info):
+    def resolve_name(self, info, **kwargs):
         return self.name
 
 
@@ -32,7 +32,7 @@ def TagsQuery():
             graphene.NonNull(TagObjectType), required=True, enable_search=False
         )
 
-        def resolve_tag(self, info, id):
+        def resolve_tag(self, info, id, **kwargs):
             try:
                 return Tag.objects.get(pk=id)
             except BaseException:


### PR DESCRIPTION
Resolves #125 

By default, all `bmp` and `webp` images are converted to the `png` format when no image output format is given.
The default conversion mapping can be changed ([docs here](https://docs.wagtail.io/en/stable/advanced_topics/images/image_file_formats.html#customizing-output-formats)).

```graphql
{
  image(id: 2) {
    id
    url
    rendition(webpquality: 75) {
      url
    }
  }
}
```

```yaml
{
  "data": {
    "image": {
      "id": 2,
      "url": "http://localhost:8000/media/original_images/file_example_WEBP_50kB.webp",
      "rendition": {
        "url": "/media/images/file_example_WEBP_50kB.webpquality-75.png"
      }
    }
  }
}
```