### PR TITLE
Use the correct type prefix with register_media_model

### DIFF
--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -114,7 +114,7 @@ def register_model(cls: type, type_prefix: str):
         elif issubclass(cls, AbstractRendition):
             register_image_model(cls, type_prefix)
         elif has_wagtail_media and issubclass(cls, AbstractMedia):
-            register_media_model(cls, AbstractMedia)
+            register_media_model(cls, type_prefix)
         elif issubclass(cls, BaseSetting):
             register_settings_model(cls, type_prefix)
         elif cls in get_snippet_models():


### PR DESCRIPTION
Not an issue with the default Media models. Trips out on custom media models with 

```
   File "/usr/local/lib/python3.8/dist-packages/grapple/actions.py", line 117, in register_model
     register_media_model(cls, AbstractMedia)
   File "/usr/local/lib/python3.8/dist-packages/grapple/actions.py", line 488, in register_media_model
     media_node_type = build_node_type(cls, type_prefix, None, MediaObjectType)
   File "/usr/local/lib/python3.8/dist-packages/grapple/actions.py", line 220, in build_node_type
     type_name = type_prefix + cls.__name__
 TypeError: unsupported operand type(s) for +: 'ModelBase' and 'str'
```

Currently don't have tests because of an issue with Wagtail 2.11 with no internationalisation