### PR TITLE
Tweak exclusion lists for pages

### DIFF
--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -270,6 +270,9 @@ def load_type_fields():
                 type_meta = {"Meta": Meta, "id": graphene.ID(), "name": type_name}
 
                 exclude_fields = []
+                base_type_for_exclusion_checks = (
+                    base_type if not issubclass(cls, WagtailPage) else WagtailPage
+                )
                 for field in get_fields_and_properties(cls):
                     # Filter out any fields that are defined on the interface of base type to prevent the
                     # 'Excluding the custom field "<field>" on DjangoObjectType "<cls>" has no effect.
@@ -277,7 +280,7 @@ def load_type_fields():
                     if (
                         field == "id"
                         or hasattr(interface, field)
-                        or hasattr(base_type, field)
+                        or hasattr(base_type_for_exclusion_checks, field)
                     ):
                         continue
 

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -22,17 +22,25 @@ from .structures import QuerySetList
 
 class PageInterface(graphene.Interface):
     id = graphene.ID()
+    title = graphene.String(required=True)
+    slug = graphene.String(required=True)
+    content_type = graphene.String(required=True)
+    page_type = graphene.String()
+    live = graphene.Boolean(required=True)
+
     url = graphene.String()
     url_path = graphene.String(required=True)
-    slug = graphene.String(required=True)
+
     depth = graphene.Int()
-    page_type = graphene.String()
-    title = graphene.String(required=True)
     seo_title = graphene.String(required=True)
-    seo_description = graphene.String()
+    search_description = graphene.String()
     show_in_menus = graphene.Boolean(required=True)
-    content_type = graphene.String(required=True)
+
+    locked = graphene.Boolean()
+
+    first_published_at = graphene.DateTime()
     last_published_at = graphene.DateTime()
+
     parent = graphene.Field(lambda: PageInterface)
     children = QuerySetList(
         graphene.NonNull(lambda: PageInterface), enable_search=True, required=True


### PR DESCRIPTION
Follow up to #146

pre v0.10.0 (and #146), any `Page` subclasses had all the `Page` fields + anything declared in their own `graphql_fields`. After, they only have the `PageInterface` fields and the declared `graphql_fields`. That is because `base_type` for Wagtail pages does not declare any attributes.

was in two minds about this, however since `Page` exposes all fields, any derived classes should do the same