### PR TITLE
Add ability to limit the renditions Grapple will generate

### DIFF
--- a/docs/general-usage/graphql-types.rst
+++ b/docs/general-usage/graphql-types.rst
@@ -166,6 +166,9 @@ GRAPPLE_ALLOWED_IMAGE_FILTERS = [
     "width-700|format-webp"
 ]
 
+Note that the ``srcSet`` attribute on ``ImageObjectType`` generates ``width-*`` filters, so if in use consider adding
+the relevant filters to the allowed list.
+
 
 DocumentObjectType
 ^^^^^^^^^^^^^^^^^^

--- a/docs/general-usage/graphql-types.rst
+++ b/docs/general-usage/graphql-types.rst
@@ -142,13 +142,29 @@ the ``ImageRenditionObjectType`` provides the following fields:
 ::
 
     id: ID
-    filterSpec: String!
+    url: String
     file: String!
     width: Int
     height: Int
-    focalPointKey: String!
+    aspectRatio: Float!
+    sizes: String!
     image: ImageObjectType!
-    url: String
+
+
+To prevent arbitrary renditions from being generated, set ``GRAPPLE_ALLOWED_IMAGE_FILTERS`` in your settings to a
+list of allowed filters. Read more about generating renditions in the Wagtail docs
+(`Generating renditions in Python <https://docs.wagtail.io/en/stable/advanced_topics/images/renditions.html#generating-renditions-in-python>` and
+`Using images in templates <https://docs.wagtail.io/en/stable/topics/images.html#image-tag>`
+
+For example:
+
+::
+
+GRAPPLE_ALLOWED_IMAGE_FILTERS = [
+    "width-1000",
+    "fill-300x150|jpegquality-60",
+    "width-700|format-webp"
+]
 
 
 DocumentObjectType

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 
 import wagtail_factories
 
+from grapple.types.images import rendition_allowed
+
 if sys.version_info >= (3, 7):
     from builtins import dict as dict_type
 else:
@@ -357,7 +359,7 @@ class ImagesTest(BaseGrappleTest):
         self.assertIn("width-100", executed["data"]["image"]["rendition"]["url"])
 
     @override_settings(GRAPPLE_ALLOWED_IMAGE_FILTERS=["width-200"])
-    def test_allowed_renditions(self):
+    def test_renditions_with_allowed_image_filters_restrictions(self):
         def get_query(**kwargs):
             params = ",".join([f"{key}: {value}" for key, value in kwargs.items()])
             return (
@@ -395,6 +397,16 @@ class ImagesTest(BaseGrappleTest):
         # only the width-200 rendition is allowed
         self.assertNotIn("width-100", executed["data"]["image"]["srcSet"])
         self.assertIn("width-200", executed["data"]["image"]["srcSet"])
+
+    def test_rendition_allowed_method(self):
+        self.assertTrue(rendition_allowed("width-100"))
+        with override_settings(GRAPPLE_ALLOWED_IMAGE_FILTERS=["width-200"]):
+            self.assertFalse(rendition_allowed("width-100"))
+            self.assertTrue(rendition_allowed("width-200"))
+
+        with override_settings(GRAPPLE_ALLOWED_IMAGE_FILTERS=[]):
+            self.assertFalse(rendition_allowed("width-100"))
+            self.assertFalse(rendition_allowed("fill-100x100"))
 
     def tearDown(self):
         example_image_path = self.example_image.file.path

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -62,8 +62,8 @@ def get_rendition_type():
 
 def rendition_allowed(rendition_filter):
     """Checks a given rendition filter is allowed"""
-    allowed_filters = getattr(settings, "GRAPPLE_ALLOWED_IMAGE_FILTERS", [])
-    if not allowed_filters:
+    allowed_filters = getattr(settings, "GRAPPLE_ALLOWED_IMAGE_FILTERS", None)
+    if allowed_filters is None or not isinstance(allowed_filters, list):
         return True
 
     return rendition_filter in allowed_filters

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -63,7 +63,7 @@ def get_rendition_type():
 def rendition_allowed(rendition_filter):
     """Checks a given rendition filter is allowed"""
     allowed_filters = getattr(settings, "GRAPPLE_ALLOWED_IMAGE_FILTERS", None)
-    if allowed_filters is None or not isinstance(allowed_filters, list):
+    if allowed_filters is None or not isinstance(allowed_filters, (list, tuple)):
         return True
 
     return rendition_filter in allowed_filters


### PR DESCRIPTION
This PR fixes #158 by adding a new `GRAPPLE_ALLOWED_IMAGE_FILTERS` setting that is a list of allowed image filters (which constitute the parameters for a rendition) before returning a rendition or a srcSet