### PR TITLE
Fix/empty list in structblock

### DIFF
--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -639,6 +639,24 @@ class BlogTest(BaseGrappleTest):
                 self.assertEquals(button["buttonText"], "Take me to the source")
                 self.assertEquals(button["buttonLink"], "https://wagtail.io/")
 
+    def test_empty_list_in_structblock(self):
+        another_blog_post = BlogPageFactory(
+            body=[("text_and_buttons", {"buttons": []})], parent=self.home
+        )
+        block_type = "TextAndButtonsBlock"
+        block_query = """
+        buttons {
+            ... on ButtonBlock {
+                buttonText
+                buttonLink
+            }
+        }
+        """
+        query_blocks = self.get_blocks_from_body(
+            block_type, block_query=block_query, page_id=another_blog_post.id
+        )
+        self.assertEqual(query_blocks, [{"blockType": "TextAndButtonsBlock", "buttons": []}])
+
     def test_singular_blog_page_query(self):
         def query():
             return """

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -655,7 +655,9 @@ class BlogTest(BaseGrappleTest):
         query_blocks = self.get_blocks_from_body(
             block_type, block_query=block_query, page_id=another_blog_post.id
         )
-        self.assertEqual(query_blocks, [{"blockType": "TextAndButtonsBlock", "buttons": []}])
+        self.assertEqual(
+            query_blocks, [{"blockType": "TextAndButtonsBlock", "buttons": []}]
+        )
 
     def test_singular_blog_page_query(self):
         def query():

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -350,7 +350,7 @@ def streamfield_resolver(self, instance, info, **kwargs):
         block = instance.block.child_blocks[field_name]
         value = get_field_value(instance, field_name)
 
-        if not block or not value:
+        if not block:
             return None
 
         if issubclass(type(block), ImageChooserBlock) and isinstance(value, int):


### PR DESCRIPTION
When you have an empty list inside a StructBlock in a StreamField, it is resolved to None. I'm not completely sure if this is really a bug, but it looks a bit like it to me. I added a test for the presumed bug and a fix. I'm not sure if this might break something else, but at least the other tests succeed.