### PR TITLE
feat: single settings GRAPPLE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Add the following to the bottom of the same settings file, where each key is the
 ```python
 # Grapple config:
 GRAPHENE = {"SCHEMA": "grapple.schema.schema"}
-GRAPPLE_APPS = {
-    "home": ""
+GRAPPLE = {
+  "APPS": ["home"],
 }
 ```
 

--- a/docs/general-usage/decorators.rst
+++ b/docs/general-usage/decorators.rst
@@ -174,6 +174,10 @@ You can now query your adverts with the following query:
         }
     }
 
+The default ``per_page`` value is 10 and can be changed with the ``GRAPPLE_PAGE_SIZE`` setting.
+
+The ``per_page`` has a maximum value of 100 by default and can be changed with the ``GRAPPLE_PAGE_SIZE_MAX`` setting.
+
 You can add custom query parameters like so:
 
 ::

--- a/docs/general-usage/decorators.rst
+++ b/docs/general-usage/decorators.rst
@@ -174,9 +174,16 @@ You can now query your adverts with the following query:
         }
     }
 
-The default ``per_page`` value is 10 and can be changed with the ``GRAPPLE_PAGE_SIZE`` setting.
+The default ``per_page`` value is 10 and can be changed with the ``GRAPPLE["PAGE_SIZE"]`` setting.
+The ``per_page`` has a maximum value of 100 by default and can be changed with the ``GRAPPLE["MAX_PAGE_SIZE"]`` setting.
 
-The ``per_page`` has a maximum value of 100 by default and can be changed with the ``GRAPPLE_PAGE_SIZE_MAX`` setting.
+::
+
+    GRAPPLE = {
+        # ...
+        "PAGE_SIZE": 10,
+        "MAX_PAGE_SIZE": 100,
+    }
 
 You can add custom query parameters like so:
 

--- a/docs/general-usage/graphql-types.rst
+++ b/docs/general-usage/graphql-types.rst
@@ -151,28 +151,6 @@ the ``ImageRenditionObjectType`` provides the following fields:
     image: ImageObjectType!
 
 
-To prevent arbitrary renditions from being generated, set ``GRAPPLE["ALLOWED_IMAGE_FILTERS"]`` in your settings to a
-list of allowed filters. Read more about generating renditions in the Wagtail docs
-(`Generating renditions in Python <https://docs.wagtail.io/en/stable/advanced_topics/images/renditions.html#generating-renditions-in-python>` and
-`Using images in templates <https://docs.wagtail.io/en/stable/topics/images.html#image-tag>`
-
-For example:
-
-::
-
-GRAPPLE = {
-    # ...
-    "ALLOWED_IMAGE_FILTERS": [
-        "width-1000",
-        "fill-300x150|jpegquality-60",
-        "width-700|format-webp",
-    ]
-}
-
-Note that the ``srcSet`` attribute on ``ImageObjectType`` generates ``width-*`` filters, so if in use consider adding
-the relevant filters to the allowed list.
-
-
 DocumentObjectType
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/general-usage/graphql-types.rst
+++ b/docs/general-usage/graphql-types.rst
@@ -151,7 +151,7 @@ the ``ImageRenditionObjectType`` provides the following fields:
     image: ImageObjectType!
 
 
-To prevent arbitrary renditions from being generated, set ``GRAPPLE_ALLOWED_IMAGE_FILTERS`` in your settings to a
+To prevent arbitrary renditions from being generated, set ``GRAPPLE["ALLOWED_IMAGE_FILTERS"]`` in your settings to a
 list of allowed filters. Read more about generating renditions in the Wagtail docs
 (`Generating renditions in Python <https://docs.wagtail.io/en/stable/advanced_topics/images/renditions.html#generating-renditions-in-python>` and
 `Using images in templates <https://docs.wagtail.io/en/stable/topics/images.html#image-tag>`
@@ -160,11 +160,14 @@ For example:
 
 ::
 
-GRAPPLE_ALLOWED_IMAGE_FILTERS = [
-    "width-1000",
-    "fill-300x150|jpegquality-60",
-    "width-700|format-webp"
-]
+GRAPPLE = {
+    # ...
+    "ALLOWED_IMAGE_FILTERS": [
+        "width-1000",
+        "fill-300x150|jpegquality-60",
+        "width-700|format-webp",
+    ]
+}
 
 Note that the ``srcSet`` attribute on ``ImageObjectType`` generates ``width-*`` filters, so if in use consider adding
 the relevant filters to the allowed list.

--- a/docs/general-usage/index.rst
+++ b/docs/general-usage/index.rst
@@ -10,3 +10,4 @@ General Usage
     decorators
     hooks
     usage-with-gatsby
+    settings

--- a/docs/general-usage/settings.rst
+++ b/docs/general-usage/settings.rst
@@ -1,0 +1,124 @@
+Settings
+========
+
+Configuration for Wagtail Grapple is all namespaced inside a single Django setting,
+named ``GRAPPLE``.
+
+For example your project's ``settings.py`` file might include something like this:
+
+::
+
+    GRAPPLE = {
+        'APPS': ['home'],
+        'ADD_SEARCH_HIT': True,
+    }
+
+
+Accessing settings
+------------------
+
+If you need to access the values of Wagtail Grapple's settings in your project, you should use the
+``grapple_settings`` object. For example.
+
+::
+
+    from grapple.settings import grapple_settings
+
+    print(grapple_settings.APPS)
+
+The ``grapple_settings`` object will check for any user-defined settings, and otherwise fall back to
+the default values.
+
+
+API Reference
+-------------
+
+
+Grapple settings
+^^^^^^^^^^^^^^^^
+
+APPS
+****
+
+A list/tuple of the apps that Grapple will scan for models to generate GraphQL types that adopt their structure.
+
+Default: ``['home']``
+
+
+AUTO_CAMELCASE
+**************
+
+By default, all field and argument names will be converted from `snake_case` to `camelCase`.
+To disable this behavior, set the ``GRAPPLE['AUTO_CAMELCASE']`` setting to `False`.
+
+Default: ``True``
+
+
+EXPOSE_GRAPHIQL
+***************
+
+By default, Grapple will add ``/graphql`` url to where you can make GET/POST GraphQL requests.
+When setting ``GRAPPLE['EXPOSE_GRAPHIQL']`` to ``True``, the ``/graphiql`` url is also added to
+provide access to GraphiQL.
+
+Default: ``False``
+
+
+Renditions settings
+^^^^^^^^^^^^^^^^^^^
+
+ALLOWED_IMAGE_FILTERS
+*********************
+
+To prevent arbitrary renditions from being generated, set ``GRAPPLE['ALLOWED_IMAGE_FILTERS']`` in
+your settings to a `list` or `tuple` of allowed filters. Read more about generating renditions in the Wagtail docs
+(`Generating renditions in Python <https://docs.wagtail.io/en/stable/advanced_topics/images/renditions.html#generating-renditions-in-python>`_ and
+`How to use images in templates <https://docs.wagtail.io/en/stable/topics/images.html#how-to-use-images-in-templates>`_)
+
+Default: ``None``
+
+Example:
+
+::
+
+    GRAPPLE = {
+        # ...
+        'ALLOWED_IMAGE_FILTERS': [
+            'width-1000',
+            'fill-300x150|jpegquality-60',
+            'width-700|format-webp',
+        ]
+    }
+
+Note that the ``srcSet`` attribute on ``ImageObjectType`` generates ``width-*`` filters, so if in use
+consider adding the relevant filters to the allowed list.
+
+
+Search settings
+^^^^^^^^^^^^^^^
+
+ADD_SEARCH_HIT
+**************
+
+Setting this to ``True`` will log search queries so Wagtail can suggest promoted results.
+
+Default: ``False``
+
+
+Pagination settings
+^^^^^^^^^^^^^^^^^^^
+
+PAGE_SIZE
+*********
+
+Value used as default for both ``QuerySetList``' ``limit`` and ``PaginatedQuerySet``' ``perPage`` arguments.
+
+Default: ``10``
+
+
+MAX_PAGE_SIZE
+*************
+
+Value used to limit the maximum of items to be returned for both ``QuerySetList`` and ``PaginatedQuerySet`` types.
+
+Default: ``100``

--- a/docs/general-usage/settings.rst
+++ b/docs/general-usage/settings.rst
@@ -42,7 +42,7 @@ APPS
 
 A list/tuple of the apps that Grapple will scan for models to generate GraphQL types that adopt their structure.
 
-Default: ``['home']``
+Default: ``[]``
 
 
 AUTO_CAMELCASE

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -57,6 +57,8 @@ Add the GraphQL urls to your ``urls.py``:
 Done! Now you can proceed onto configuring your models to generate
 GraphQL types that adopt their structure.
 
+By default, Grapple uses :doc:`these settings <../general-usage/settings>`.
+
 * **Next Steps**
 
   * :doc:`examples`

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -54,16 +54,8 @@ Add the GraphQL urls to your ``urls.py``:
         ...
     ]
 
-By default, Grapple will add ``/graphql`` url to where you can make GET/POST GraphQL requests.
-When ``DEBUG`` is enabled on the settings or ``GRAPPLE["EXPOSE_GRAPHIQL"]`` is set to ``True``,
-the ``/graphiql`` url is also added to provide access to GraphiQL (a graphical interactive in-browser GraphQL IDE).
-
 Done! Now you can proceed onto configuring your models to generate
 GraphQL types that adopt their structure.
-
-By default, all field and argument names will be converted from ``snake_case``
-to ``camelCase``. To disable this behavior, set the ``GRAPPLE["AUTO_CAMELCASE"]``
-setting to `False` on your project settings.
 
 * **Next Steps**
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -10,25 +10,25 @@ settings file:
 
 ::
 
-   installed_apps = [
-       ...
-       "grapple",
-       "graphene_django",
-       ...
-   ]
+    installed_apps = [
+        ...
+        "grapple",
+        "graphene_django",
+        ...
+    ]
 
 For GraphQL Subscriptions with Django Channels, run ``pip install wagtail_grapple[channels]`` and add
 ``channels`` to installed apps:
 
 ::
 
-   installed_apps = [
-       ...
-       "grapple",
-       "graphene_django",
-       "channels",
-       ...
-   ]
+    installed_apps = [
+        ...
+        "grapple",
+        "graphene_django",
+        "channels",
+        ...
+    ]
 
 Add the following to the bottom of the same settings file where each key
 is the app you want to this library to scan and the value is the prefix
@@ -36,29 +36,33 @@ you want to give to GraphQL types (you can usually leave this blank):
 
 ::
 
-   # Grapple Config:
-   GRAPHENE = {"SCHEMA": "grapple.schema.schema"}
-   GRAPPLE_APPS = {
-       "home": ""
-   }
+    # Grapple Config:
+    GRAPHENE = {"SCHEMA": "grapple.schema.schema"}
+    GRAPPLE = {
+        "APPS": ["home"],
+    }
 
 Add the GraphQL urls to your ``urls.py``:
 
 ::
 
-   from grapple import urls as grapple_urls
-   ...
-   urlpatterns = [
-       ...
-       url(r"", include(grapple_urls)),
-       ...
-   ]
+    from grapple import urls as grapple_urls
+    ...
+    urlpatterns = [
+        ...
+        url(r"", include(grapple_urls)),
+        ...
+    ]
+
+By default, Grapple will add ``/graphql`` url to where you can make GET/POST GraphQL requests.
+When ``DEBUG`` is enabled on the settings or ``GRAPPLE["EXPOSE_GRAPHIQL"]`` is set to ``True``,
+the ``/graphiql`` url is also added to provide access to GraphiQL (a graphical interactive in-browser GraphQL IDE).
 
 Done! Now you can proceed onto configuring your models to generate
 GraphQL types that adopt their structure.
 
-By default, all field and argument names will be converted from `snake_case`
-to `camelCase`. To disable this behavior, set the `GRAPPLE_AUTO_CAMELCASE`
+By default, all field and argument names will be converted from ``snake_case``
+to ``camelCase``. To disable this behavior, set the ``GRAPPLE["AUTO_CAMELCASE"]``
 setting to `False` on your project settings.
 
 * **Next Steps**

--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -171,10 +171,12 @@ CORS_ORIGIN_ALLOW_ALL = True
 
 # Grapple Config:
 GRAPHENE = {"SCHEMA": "grapple.schema.schema"}
-GRAPPLE_APPS = {"images": "", "home": "", "documents": ""}
-GRAPPLE_ADD_SEARCH_HIT = True
-GRAPPLE_PAGE_SIZE = 10
-GRAPPLE_PAGE_SIZE_MAX = 50
+GRAPPLE = {
+    "APPS": ["images", "home", "documents"],
+    "ADD_SEARCH_HIT": True,
+    "PAGE_SIZE": 5,
+    "MAX_PAGE_SIZE": 6,
+}
 
 HEADLESS_PREVIEW_CLIENT_URLS = {"default": "http://localhost:8001/preview"}
 HEADLESS_PREVIEW_LIVE = True

--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -174,8 +174,6 @@ GRAPHENE = {"SCHEMA": "grapple.schema.schema"}
 GRAPPLE = {
     "APPS": ["images", "home", "documents"],
     "ADD_SEARCH_HIT": True,
-    "PAGE_SIZE": 5,
-    "MAX_PAGE_SIZE": 6,
 }
 
 HEADLESS_PREVIEW_CLIENT_URLS = {"default": "http://localhost:8001/preview"}

--- a/example/example/settings/base.py
+++ b/example/example/settings/base.py
@@ -173,6 +173,8 @@ CORS_ORIGIN_ALLOW_ALL = True
 GRAPHENE = {"SCHEMA": "grapple.schema.schema"}
 GRAPPLE_APPS = {"images": "", "home": "", "documents": ""}
 GRAPPLE_ADD_SEARCH_HIT = True
+GRAPPLE_PAGE_SIZE = 10
+GRAPPLE_PAGE_SIZE_MAX = 50
 
 HEADLESS_PREVIEW_CLIENT_URLS = {"default": "http://localhost:8001/preview"}
 HEADLESS_PREVIEW_LIVE = True

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -74,6 +74,30 @@ class PagesTest(BaseGrappleTest):
         pages = Page.objects.filter(depth__gt=1)
         self.assertEquals(len(executed["data"]["pages"]), pages.count())
 
+    @override_settings(GRAPPLE={"PAGE_SIZE": 1, "MAX_PAGE_SIZE": 1})
+    def test_pages_limit(self):
+        query = """
+        {
+            pages(limit: 5) {
+                id
+                title
+                contentType
+                pageType
+            }
+        }
+        """
+
+        executed = self.client.execute(query)
+
+        self.assertEquals(type(executed["data"]), dict_type)
+        self.assertEquals(type(executed["data"]["pages"]), list)
+        self.assertEquals(type(executed["data"]["pages"][0]), dict_type)
+
+        pages_data = executed["data"]["pages"]
+        self.assertEquals(pages_data[0]["contentType"], "home.HomePage")
+        self.assertEquals(pages_data[0]["pageType"], "HomePage")
+        self.assertEquals(len(executed["data"]["pages"]), 1)
+
     def test_pages_in_site(self):
         query = """
         {

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -350,7 +350,7 @@ class SitesTest(TestCase):
         self.assertEquals(data[0]["title"], blog.title)
 
 
-@override_settings(GRAPPLE_AUTO_CAMELCASE=False)
+@override_settings(GRAPPLE={**settings.GRAPPLE, "AUTO_CAMELCASE": False})
 class DisableAutoCamelCaseTest(TestCase):
     def setUp(self):
         schema = create_schema()
@@ -432,7 +432,9 @@ class ImagesTest(BaseGrappleTest):
         executed = self.client.execute(query)
         self.assertIn("width-100", executed["data"]["image"]["rendition"]["url"])
 
-    @override_settings(GRAPPLE_ALLOWED_IMAGE_FILTERS=["width-200"])
+    @override_settings(
+        GRAPPLE={**settings.GRAPPLE, "ALLOWED_IMAGE_FILTERS": ["width-200"]}
+    )
     def test_renditions_with_allowed_image_filters_restrictions(self):
         def get_query(**kwargs):
             params = ",".join([f"{key}: {value}" for key, value in kwargs.items()])
@@ -456,7 +458,9 @@ class ImagesTest(BaseGrappleTest):
         self.assertIsNotNone(executed["data"]["image"]["rendition"])
         self.assertIn("width-200", executed["data"]["image"]["rendition"]["url"])
 
-    @override_settings(GRAPPLE_ALLOWED_IMAGE_FILTERS=["width-200"])
+    @override_settings(
+        GRAPPLE={**settings.GRAPPLE, "ALLOWED_IMAGE_FILTERS": ["width-200"]}
+    )
     def test_src_set(self):
         query = """
         {
@@ -474,11 +478,15 @@ class ImagesTest(BaseGrappleTest):
 
     def test_rendition_allowed_method(self):
         self.assertTrue(rendition_allowed("width-100"))
-        with override_settings(GRAPPLE_ALLOWED_IMAGE_FILTERS=["width-200"]):
+        with override_settings(
+            GRAPPLE={**settings.GRAPPLE, "ALLOWED_IMAGE_FILTERS": ["width-200"]}
+        ):
             self.assertFalse(rendition_allowed("width-100"))
             self.assertTrue(rendition_allowed("width-200"))
 
-        with override_settings(GRAPPLE_ALLOWED_IMAGE_FILTERS=[]):
+        with override_settings(
+            GRAPPLE={**settings.GRAPPLE, "ALLOWED_IMAGE_FILTERS": []}
+        ):
             self.assertFalse(rendition_allowed("width-100"))
             self.assertFalse(rendition_allowed("fill-100x100"))
 

--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -350,7 +350,7 @@ class SitesTest(TestCase):
         self.assertEquals(data[0]["title"], blog.title)
 
 
-@override_settings(GRAPPLE={**settings.GRAPPLE, "AUTO_CAMELCASE": False})
+@override_settings(GRAPPLE={"AUTO_CAMELCASE": False})
 class DisableAutoCamelCaseTest(TestCase):
     def setUp(self):
         schema = create_schema()
@@ -432,9 +432,7 @@ class ImagesTest(BaseGrappleTest):
         executed = self.client.execute(query)
         self.assertIn("width-100", executed["data"]["image"]["rendition"]["url"])
 
-    @override_settings(
-        GRAPPLE={**settings.GRAPPLE, "ALLOWED_IMAGE_FILTERS": ["width-200"]}
-    )
+    @override_settings(GRAPPLE={"ALLOWED_IMAGE_FILTERS": ["width-200"]})
     def test_renditions_with_allowed_image_filters_restrictions(self):
         def get_query(**kwargs):
             params = ",".join([f"{key}: {value}" for key, value in kwargs.items()])
@@ -458,9 +456,7 @@ class ImagesTest(BaseGrappleTest):
         self.assertIsNotNone(executed["data"]["image"]["rendition"])
         self.assertIn("width-200", executed["data"]["image"]["rendition"]["url"])
 
-    @override_settings(
-        GRAPPLE={**settings.GRAPPLE, "ALLOWED_IMAGE_FILTERS": ["width-200"]}
-    )
+    @override_settings(GRAPPLE={"ALLOWED_IMAGE_FILTERS": ["width-200"]})
     def test_src_set(self):
         query = """
         {
@@ -478,15 +474,11 @@ class ImagesTest(BaseGrappleTest):
 
     def test_rendition_allowed_method(self):
         self.assertTrue(rendition_allowed("width-100"))
-        with override_settings(
-            GRAPPLE={**settings.GRAPPLE, "ALLOWED_IMAGE_FILTERS": ["width-200"]}
-        ):
+        with override_settings(GRAPPLE={"ALLOWED_IMAGE_FILTERS": ["width-200"]}):
             self.assertFalse(rendition_allowed("width-100"))
             self.assertTrue(rendition_allowed("width-200"))
 
-        with override_settings(
-            GRAPPLE={**settings.GRAPPLE, "ALLOWED_IMAGE_FILTERS": []}
-        ):
+        with override_settings(GRAPPLE={"ALLOWED_IMAGE_FILTERS": []}):
             self.assertFalse(rendition_allowed("width-100"))
             self.assertFalse(rendition_allowed("fill-100x100"))
 

--- a/example/example/tests/test_settings.py
+++ b/example/example/tests/test_settings.py
@@ -1,0 +1,43 @@
+from django.test import TestCase, override_settings
+
+from grapple.settings import (
+    DEPRECATED_SETTINGS,
+    REMOVED_SETTINGS,
+    GrappleSettings,
+    grapple_settings,
+)
+
+
+class TestSettings(TestCase):
+    def test_warning_raised_on_deprecated_setting(self):
+        """
+        Make sure user is alerted with an warning when a deprecated setting is set.
+        """
+        if len(DEPRECATED_SETTINGS) > 0:
+            with self.assertLogs("grapple", level="WARNING"):
+                user_settings = {}
+                user_settings[DEPRECATED_SETTINGS[0]] = True
+                GrappleSettings(user_settings)
+
+    def test_error_raised_on_removed_setting(self):
+        """
+        Make sure user is alerted with an error when a removed setting is set.
+        """
+        if len(REMOVED_SETTINGS) > 0:
+            with self.assertRaises(RuntimeError):
+                user_settings = {}
+                user_settings[REMOVED_SETTINGS[0]] = True
+                GrappleSettings(user_settings)
+
+    def test_compatibility_with_override_settings(self):
+        """
+        Usage of grapple_settings is bound at import time:
+            from grapple.settings import grapple_settings
+        setting_changed signal hook must ensure bound instance is refreshed.
+        """
+        self.assertEquals(grapple_settings.PAGE_SIZE, 10)
+
+        with override_settings(GRAPPLE={"PAGE_SIZE": 5}):
+            self.assertEquals(grapple_settings.PAGE_SIZE, 5)
+
+        self.assertEquals(grapple_settings.PAGE_SIZE, 10)

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -12,19 +12,8 @@ from wagtail.core.rich_text import RichText
 from wagtail.embeds.blocks import EmbedValue
 
 from example.tests.test_grapple import BaseGrappleTest
-from home.blocks import (
-    ButtonBlock,
-    CarouselBlock,
-    ImageGalleryImage,
-    ImageGalleryImages,
-    VideoBlock,
-)
-from home.factories import (
-    BlogPageFactory,
-    BlogPageRelatedLinkFactory,
-    ImageGalleryImageFactory,
-    AuthorPageFactory,
-)
+from home.blocks import CarouselBlock, ImageGalleryImages
+from home.factories import BlogPageFactory
 
 
 class BlogTest(BaseGrappleTest):
@@ -337,8 +326,8 @@ class BlogTest(BaseGrappleTest):
             title
             images {
                 image {
-                  id
-                  src
+                    id
+                    src
                 }
             }
             """,

--- a/example/home/test/test_general.py
+++ b/example/home/test/test_general.py
@@ -1,3 +1,4 @@
+from django.test import override_settings
 from example.tests.test_grapple import BaseGrappleTest
 
 from home.factories import BlogPageFactory, SimpleModelFactory
@@ -128,7 +129,7 @@ class TestRegisterPaginatedQueryField(BaseGrappleTest):
                     id
                 }
                 pagination {
-                  totalPages
+                    totalPages
                 }
             }
         }
@@ -138,6 +139,50 @@ class TestRegisterPaginatedQueryField(BaseGrappleTest):
         self.assertEqual(len(data["items"]), 1)
         self.assertEqual(int(data["items"][0]["id"]), self.child_post.id)
         self.assertEqual(int(data["pagination"]["totalPages"]), 3)
+
+    @override_settings(GRAPPLE={"PAGE_SIZE": 2})
+    def test_query_field_plural_default_per_page(self):
+        query = """
+        {
+            blogPages {
+                items {
+                    id
+                }
+                pagination {
+                    perPage
+                    totalPages
+                }
+            }
+        }
+        """
+        results = self.client.execute(query)
+        data = results["data"]["blogPages"]
+        self.assertEqual(len(data["items"]), 2)
+        self.assertEqual(int(data["items"][0]["id"]), self.child_post.id)
+        self.assertEqual(int(data["pagination"]["perPage"]), 2)
+        self.assertEqual(int(data["pagination"]["totalPages"]), 2)
+
+    @override_settings(GRAPPLE={"MAX_PAGE_SIZE": 3})
+    def test_query_field_plural_default_max_per_page(self):
+        query = """
+        {
+            blogPages(perPage: 5) {
+                items {
+                    id
+                }
+                pagination {
+                    perPage
+                    totalPages
+                }
+            }
+        }
+        """
+        results = self.client.execute(query)
+        data = results["data"]["blogPages"]
+        self.assertEqual(len(data["items"]), 3)
+        self.assertEqual(int(data["items"][0]["id"]), self.child_post.id)
+        self.assertEqual(int(data["pagination"]["perPage"]), 3)
+        self.assertEqual(int(data["pagination"]["totalPages"]), 1)
 
     def test_query_field(self):
         def query(filters):

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -53,10 +53,15 @@ def import_apps():
     """
 
     # Register each app in the django project.
-    apps = settings.GRAPPLE_APPS.items()
-    for name, prefix in apps:
-        add_app(name, prefix)
-        registry.apps.append(name)
+    if isinstance(settings.GRAPPLE["APPS"], (list, tuple)):
+        for name in settings.GRAPPLE["APPS"]:
+            add_app(name)
+            registry.apps.append(name)
+    else:
+        apps = settings.GRAPPLE["APPS"].items()
+        for name, prefix in apps:
+            add_app(name, prefix)
+            registry.apps.append(name)
 
     # Register any 'decorated' streamfield structs.
     for streamfield_type in streamfield_types:

--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -5,7 +5,6 @@ from types import MethodType
 from collections.abc import Iterable
 
 from django.db import models
-from django.conf import settings
 from django.template.loader import render_to_string
 
 from graphene_django.types import DjangoObjectType
@@ -25,6 +24,7 @@ from .types.images import ImageObjectType
 from .types.pages import PageInterface, Page
 from .types.streamfield import generate_streamfield_union
 from .helpers import streamfield_types
+from .settings import grapple_settings
 
 try:
     from wagtailmedia.models import AbstractMedia
@@ -53,12 +53,12 @@ def import_apps():
     """
 
     # Register each app in the django project.
-    if isinstance(settings.GRAPPLE["APPS"], (list, tuple)):
-        for name in settings.GRAPPLE["APPS"]:
+    if isinstance(grapple_settings.APPS, (list, tuple)):
+        for name in grapple_settings.APPS:
             add_app(name)
             registry.apps.append(name)
     else:
-        apps = settings.GRAPPLE["APPS"].items()
+        apps = grapple_settings.APPS.items()
         for name, prefix in apps:
             add_app(name, prefix)
             registry.apps.append(name)

--- a/grapple/schema.py
+++ b/grapple/schema.py
@@ -1,10 +1,10 @@
 import graphene
 
-from django.conf import settings
 from graphql.validation.rules import NoUnusedFragments, specified_rules
 from wagtail.core import hooks
 
 from .registry import registry
+from .settings import grapple_settings
 
 
 # HACK: Remove NoUnusedFragments validator
@@ -51,7 +51,7 @@ def create_schema():
         query=Query,
         subscription=Subscription,
         types=list(registry.models.values()),
-        auto_camelcase=getattr(settings.GRAPPLE, "AUTO_CAMELCASE", True),
+        auto_camelcase=grapple_settings.AUTO_CAMELCASE,
     )
 
 

--- a/grapple/schema.py
+++ b/grapple/schema.py
@@ -51,7 +51,7 @@ def create_schema():
         query=Query,
         subscription=Subscription,
         types=list(registry.models.values()),
-        auto_camelcase=getattr(settings, "GRAPPLE_AUTO_CAMELCASE", True),
+        auto_camelcase=getattr(settings.GRAPPLE, "AUTO_CAMELCASE", True),
     )
 
 

--- a/grapple/settings.py
+++ b/grapple/settings.py
@@ -1,0 +1,84 @@
+"""
+Settings for Wagtail Grapple are all namespaced in the GRAPPLE setting.
+For example your project's `settings.py` file might look like this:
+GRAPPLE = {
+    'APPS': ['home'],
+    'ADD_SEARCH_HIT': True,
+}
+This module provides the `grapple_settings` object, that is used to access
+Wagtail Grapple settings, checking for user settings first, then falling
+back to the defaults.
+"""
+from django.conf import settings
+from django.test.signals import setting_changed
+
+
+DEFAULTS = {
+    "APPS": ["home"],
+    "AUTO_CAMELCASE": True,
+    "ALLOWED_IMAGE_FILTERS": None,
+    "EXPOSE_GRAPHIQL": False,
+    "ADD_SEARCH_HIT": False,
+    "PAGE_SIZE": 10,
+    "MAX_PAGE_SIZE": 100,
+}
+
+
+class GrappleSettings:
+    """
+    A settings object that allows Wagtail Grapple settings to be accessed as
+    properties. For example:
+        from grapple.settings import grapple_settings
+        print(grapple_settings.APPS)
+    Note:
+    This is an internal class that is only compatible with settings namespaced
+    under the GRAPPLE name. It is not intended to be used by 3rd-party
+    apps, and test helpers like `override_settings` may not work as expected.
+    """
+
+    def __init__(self, user_settings=None, defaults=None):
+        if user_settings:
+            self._user_settings = user_settings
+        self.defaults = defaults or DEFAULTS
+        self._cached_attrs = set()
+
+    @property
+    def user_settings(self):
+        if not hasattr(self, "_user_settings"):
+            self._user_settings = getattr(settings, "GRAPPLE", {})
+        return self._user_settings
+
+    def __getattr__(self, attr):
+        if attr not in self.defaults:
+            raise AttributeError("Invalid Grapple setting: '%s'" % attr)
+
+        try:
+            # Check if present in user settings
+            val = self.user_settings[attr]
+        except KeyError:
+            # Fall back to defaults
+            val = self.defaults[attr]
+
+        # Cache the result
+        self._cached_attrs.add(attr)
+        setattr(self, attr, val)
+        return val
+
+    def reload(self):
+        for attr in self._cached_attrs:
+            delattr(self, attr)
+        self._cached_attrs.clear()
+        if hasattr(self, "_user_settings"):
+            delattr(self, "_user_settings")
+
+
+grapple_settings = GrappleSettings(None, DEFAULTS)
+
+
+def reload_grapple_settings(*args, **kwargs):
+    setting = kwargs["setting"]
+    if setting == "GRAPPLE":
+        grapple_settings.reload()
+
+
+setting_changed.connect(reload_grapple_settings)

--- a/grapple/settings.py
+++ b/grapple/settings.py
@@ -14,7 +14,7 @@ from django.test.signals import setting_changed
 
 
 DEFAULTS = {
-    "APPS": ["home"],
+    "APPS": [],
     "AUTO_CAMELCASE": True,
     "ALLOWED_IMAGE_FILTERS": None,
     "EXPOSE_GRAPHIQL": False,

--- a/grapple/templates/grapple/graphiql.html
+++ b/grapple/templates/grapple/graphiql.html
@@ -13,12 +13,14 @@
     }
   </style>
   <link href="https://unpkg.com/graphiql@{{GRAPHIQL_VERSION}}/graphiql.min.css" rel="stylesheet" crossorigin="anonymous" />
-  <script src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/whatwg-fetch@3.6.2/dist/fetch.umd.js" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/react@{{REACT_VERSION}}/umd/react.production.min.js" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/react-dom@{{REACT_VERSION}}/umd/react-dom.production.min.js" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/graphiql@{{GRAPHIQL_VERSION}}/graphiql.min.js" crossorigin="anonymous"></script>
+  {% if supports_subscriptions %}
   <script src="https://unpkg.com/subscriptions-transport-ws@{{SUBSCRIPTIONS_TRANSPORT_VERSION}}/browser/client.js" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js" crossorigin="anonymous"></script>
+  {% endif %}
 </head>
 <body>
   <div id="graphiql"></div>

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -1,6 +1,5 @@
 import graphene
 
-from django.conf import settings
 from graphene_django import DjangoObjectType
 from wagtail.images import get_image_model
 from wagtail.images.models import (
@@ -10,6 +9,7 @@ from wagtail.images.models import (
 
 from ..registry import registry
 from ..utils import resolve_queryset, get_media_item_url
+from ..settings import grapple_settings
 from .collections import CollectionObjectType
 from .structures import QuerySetList
 
@@ -62,7 +62,7 @@ def get_rendition_type():
 
 def rendition_allowed(rendition_filter):
     """Checks a given rendition filter is allowed"""
-    allowed_filters = getattr(settings.GRAPPLE, "ALLOWED_IMAGE_FILTERS", None)
+    allowed_filters = grapple_settings.ALLOWED_IMAGE_FILTERS
     if allowed_filters is None or not isinstance(allowed_filters, (list, tuple)):
         return True
 

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -62,7 +62,7 @@ def get_rendition_type():
 
 def rendition_allowed(rendition_filter):
     """Checks a given rendition filter is allowed"""
-    allowed_filters = getattr(settings, "GRAPPLE_ALLOWED_IMAGE_FILTERS", None)
+    allowed_filters = getattr(settings.GRAPPLE, "ALLOWED_IMAGE_FILTERS", None)
     if allowed_filters is None or not isinstance(allowed_filters, (list, tuple)):
         return True
 

--- a/grapple/types/structures.py
+++ b/grapple/types/structures.py
@@ -172,7 +172,6 @@ def PaginatedQuerySet(of_type, type_class, **kwargs):
     if "page" not in kwargs:
         kwargs["page"] = graphene.Argument(
             PositiveInt,
-            default_value=1,
             description=_("Page of resulting objects to return."),
         )
 
@@ -180,7 +179,6 @@ def PaginatedQuerySet(of_type, type_class, **kwargs):
     if "per_page" not in kwargs:
         kwargs["per_page"] = graphene.Argument(
             PositiveInt,
-            default_value=10,
             description=_("The maximum number of items to include on a page."),
         )
 

--- a/grapple/urls.py
+++ b/grapple/urls.py
@@ -30,10 +30,9 @@ def graphiql(request):
 
 
 # Traditional URL routing
-SHOULD_EXPOSE_GRAPHIQL = grapple_settings.EXPOSE_GRAPHIQL
 urlpatterns = [url(r"^graphql", csrf_exempt(GraphQLView.as_view()))]
 
-if SHOULD_EXPOSE_GRAPHIQL:
+if grapple_settings.EXPOSE_GRAPHIQL:
     urlpatterns.append(url(r"^graphiql", graphiql))
 
 if has_channels:

--- a/grapple/urls.py
+++ b/grapple/urls.py
@@ -16,13 +16,13 @@ except ImportError:
 
 def graphiql(request):
     graphiql_settings = {
-        "REACT_VERSION": "16.13.1",
-        "GRAPHIQL_VERSION": "0.17.5",
+        "REACT_VERSION": "16.14.0",
+        "GRAPHIQL_VERSION": "1.4.2",
         "endpointURL": "/graphql",
         "supports_subscriptions": has_channels,
     }
     if has_channels:
-        graphiql_settings["SUBSCRIPTIONS_TRANSPORT_VERSION"] = "0.9.16"
+        graphiql_settings["SUBSCRIPTIONS_TRANSPORT_VERSION"] = "0.9.19"
         graphiql_settings["subscriptionsEndpoint"] = "ws://localhost:8000/subscriptions"
 
     return render(request, "grapple/graphiql.html", graphiql_settings)
@@ -30,7 +30,7 @@ def graphiql(request):
 
 # Traditional URL routing
 SHOULD_EXPOSE_GRAPHIQL = settings.DEBUG or getattr(
-    settings, "GRAPPLE_EXPOSE_GRAPHIQL", False
+    settings.GRAPPLE, "EXPOSE_GRAPHIQL", False
 )
 urlpatterns = [url(r"^graphql", csrf_exempt(GraphQLView.as_view()))]
 

--- a/grapple/urls.py
+++ b/grapple/urls.py
@@ -1,9 +1,10 @@
-from django.conf import settings
 from django.shortcuts import render
 from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
 
 from graphene_django.views import GraphQLView
+
+from .settings import grapple_settings
 
 try:
     from channels.routing import route_class
@@ -29,9 +30,7 @@ def graphiql(request):
 
 
 # Traditional URL routing
-SHOULD_EXPOSE_GRAPHIQL = settings.DEBUG or getattr(
-    settings.GRAPPLE, "EXPOSE_GRAPHIQL", False
-)
+SHOULD_EXPOSE_GRAPHIQL = grapple_settings.EXPOSE_GRAPHIQL
 urlpatterns = [url(r"^graphql", csrf_exempt(GraphQLView.as_view()))]
 
 if SHOULD_EXPOSE_GRAPHIQL:

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -10,8 +10,8 @@ from wagtail.search.backends import get_search_backend
 
 from .types.structures import BasePaginatedType, PaginationType
 
-GRAPPLE_PAGE_SIZE = getattr(settings, "GRAPPLE_PAGE_SIZE", 10)
-GRAPPLE_PAGE_SIZE_MAX = getattr(settings, "GRAPPLE_PAGE_SIZE_MAX", 100)
+PAGE_SIZE = getattr(settings.GRAPPLE, "PAGE_SIZE", 10)
+MAX_PAGE_SIZE = getattr(settings.GRAPPLE, "PAGE_SIZE_MAX", 100)
 
 
 def resolve_queryset(
@@ -57,7 +57,7 @@ def resolve_queryset(
         if not class_is_indexed(qs.model):
             raise TypeError("This data type is not searchable by Wagtail.")
 
-        if settings.GRAPPLE_ADD_SEARCH_HIT is True:
+        if getattr(settings.GRAPPLE, "ADD_SEARCH_HIT", False):
             query = Query.get(search_query)
             query.add_hit()
 
@@ -74,7 +74,7 @@ def resolve_queryset(
             pass
 
     if limit is not None:
-        limit = min(int(limit or GRAPPLE_PAGE_SIZE), GRAPPLE_PAGE_SIZE_MAX)
+        limit = min(int(limit or PAGE_SIZE), MAX_PAGE_SIZE)
         qs = qs[offset : limit + offset]
 
     return qs
@@ -135,7 +135,7 @@ def resolve_paginated_queryset(
     :type order: str
     """
     page = int(page or 1)
-    per_page = min(int(per_page or GRAPPLE_PAGE_SIZE), GRAPPLE_PAGE_SIZE_MAX)
+    per_page = min(int(per_page or PAGE_SIZE), MAX_PAGE_SIZE)
 
     if id is not None:
         qs = qs.filter(pk=id)
@@ -147,7 +147,7 @@ def resolve_paginated_queryset(
         if not class_is_indexed(qs.model):
             raise TypeError("This data type is not searchable by Wagtail.")
 
-        if settings.GRAPPLE_ADD_SEARCH_HIT is True:
+        if getattr(settings.GRAPPLE, "ADD_SEARCH_HIT", False):
             query = Query.get(search_query)
             query.add_hit()
 

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -9,9 +9,7 @@ from wagtail.search.models import Query
 from wagtail.search.backends import get_search_backend
 
 from .types.structures import BasePaginatedType, PaginationType
-
-PAGE_SIZE = getattr(settings.GRAPPLE, "PAGE_SIZE", 10)
-MAX_PAGE_SIZE = getattr(settings.GRAPPLE, "PAGE_SIZE_MAX", 100)
+from .settings import grapple_settings
 
 
 def resolve_queryset(
@@ -57,7 +55,7 @@ def resolve_queryset(
         if not class_is_indexed(qs.model):
             raise TypeError("This data type is not searchable by Wagtail.")
 
-        if getattr(settings.GRAPPLE, "ADD_SEARCH_HIT", False):
+        if grapple_settings.ADD_SEARCH_HIT:
             query = Query.get(search_query)
             query.add_hit()
 
@@ -74,7 +72,9 @@ def resolve_queryset(
             pass
 
     if limit is not None:
-        limit = min(int(limit or PAGE_SIZE), MAX_PAGE_SIZE)
+        limit = min(
+            int(limit or grapple_settings.PAGE_SIZE), grapple_settings.MAX_PAGE_SIZE
+        )
         qs = qs[offset : limit + offset]
 
     return qs
@@ -135,7 +135,9 @@ def resolve_paginated_queryset(
     :type order: str
     """
     page = int(page or 1)
-    per_page = min(int(per_page or PAGE_SIZE), MAX_PAGE_SIZE)
+    per_page = min(
+        int(per_page or grapple_settings.PAGE_SIZE), grapple_settings.MAX_PAGE_SIZE
+    )
 
     if id is not None:
         qs = qs.filter(pk=id)
@@ -147,7 +149,7 @@ def resolve_paginated_queryset(
         if not class_is_indexed(qs.model):
             raise TypeError("This data type is not searchable by Wagtail.")
 
-        if getattr(settings.GRAPPLE, "ADD_SEARCH_HIT", False):
+        if grapple_settings.ADD_SEARCH_HIT:
             query = Query.get(search_query)
             query.add_hit()
 


### PR DESCRIPTION
- [x] Grapple setting object
    - [x] backwards compatibility
    - [x] deprecated settings warnings
    - [x] removed settings errors
- [x] documentation
    - [x] all settings available
    - [x] settings defaults
- [x] tests

All Wagtail Grapple settings are now done via the `GRAPPLE` settings object.

```python
# Your project settings file
GRAPPLE = {
    "APPS": ["home", "images", "documents"],
    "AUTO_CAMELCASE": True,
    "ADD_SEARCH_HIT": False,
    "EXPOSE_GRAPHIQL": False,
    "ALLOWED_IMAGE_FILTERS": [
        "width-1000",
        "fill-300x150|jpegquality-60",
        "width-700|format-webp",
    ],
}
```

This adds support for customizing the pagination `limit`/`per_page` default and maximum values.
This can be done by using the following settings:
```python
# Your project settings file
GRAPPLE = {
    # ...
    "PAGE_SIZE": 15, # default 10
    "MAX_PAGE_SIZE": 30, # default 100
}
```