### PR TITLE
add support for specifying custom resolvers

### DIFF
--- a/grapple/actions.py
+++ b/grapple/actions.py
@@ -166,8 +166,14 @@ def get_field_type(field):
         else:
             return field, graphene.Field(field_type)
 
+def get_wrapped_custom_resolver(field):
+    if not field.resolver:
+        return None
+    return lambda self, instance, info, **kwargs: field.resolver(instance, info, **kwargs)
 
 def model_resolver(field):
+    if field.resolver:
+        return get_wrapped_custom_resolver(field)
     def mixin(self, instance, info, **kwargs):
         from .utils import resolve_queryset
 
@@ -399,7 +405,7 @@ def build_streamfield_type(
             field, field_type = get_field_type(field)
 
             # Add support for `graphql_fields`
-            methods["resolve_" + field.field_name] = streamfield_resolver
+            methods["resolve_" + field.field_name] = get_wrapped_custom_resolver(field) or streamfield_resolver
 
             # Add field to GQL type with correct field-type
             type_meta[field.field_name] = field_type

--- a/grapple/models.py
+++ b/grapple/models.py
@@ -1,3 +1,4 @@
+from typing import Callable
 import graphene
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
@@ -10,13 +11,16 @@ class GraphQLField:
     field_name: str
     field_type: str
     field_source: str
+    # A standard graphene resolver
+    resolver: Callable
 
     def __init__(
-        self, field_name: str, field_type: type = None, required=None, **kwargs
+        self, field_name: str, field_type: type = None, required=None, resolver=None, **kwargs
     ):
         # Initiate and get specific field info.
         self.field_name = field_name
         self.field_type = field_type
+        self.resolver = resolver
         self.field_source = kwargs.get("source", field_name)
 
         # Add support for NonNull/required fields


### PR DESCRIPTION
Adds basic support for custom resolvers. It would be nice if specifying custom arguments was supported too, but for that we probably need to rethink the design (how/where to specify arguments etc.)
closes #179 