### PR TITLE
Use absolute URL for renditions

### DIFF
--- a/example/example/tests/test_grapple.py
+++ b/example/example/tests/test_grapple.py
@@ -457,6 +457,27 @@ class ImagesTest(BaseGrappleTest):
             executed["data"]["images"][0]["url"], executed["data"]["images"][0]["src"]
         )
 
+    def test_query_rendition_url_field(self):
+        query = """
+        {
+            images {
+                id
+                rendition(width: 200) {
+                    url
+                }
+            }
+        }
+        """
+
+        executed = self.client.execute(query)
+
+        self.assertEquals(executed["data"]["images"][0]["id"], "1")
+        self.assertEquals(
+            executed["data"]["images"][0]["rendition"]["url"],
+            "http://localhost:8000"
+            + self.example_image.get_rendition("width-200").file.url,
+        )
+
     def test_renditions(self):
         query = """
         {

--- a/grapple/types/images.py
+++ b/grapple/types/images.py
@@ -103,7 +103,7 @@ class ImageObjectType(DjangoObjectType, BaseImageObjectType):
 
                 rendition = rendition_type(
                     id=img.id,
-                    url=img.url,
+                    url=get_media_item_url(img),
                     width=img.width,
                     height=img.height,
                     file=img.file,


### PR DESCRIPTION
Grapple currently returns a relative URL for images renditions.
This PR addresses this issue 