### PR TITLE
fix: docker build cannot find ../requirements

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -6,10 +6,12 @@ LABEL maintainer="hello@wagtail.io"
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_ENV dev
 
+COPY ./requirements-channels.txt /code/requirements-channels.txt
 COPY ./requirements.txt /code/requirements.txt
+
 RUN pip install --upgrade pip
 # Install any needed packages specified in requirements.txt
-RUN pip install -r /code/requirements.txt
+RUN pip install -r /code/requirements-channels.txt
 RUN pip install gunicorn
 
 # Copy the current directory contents into the container at /code/

--- a/example/requirements-channels.txt
+++ b/example/requirements-channels.txt
@@ -1,5 +1,5 @@
-# Project channel requirements
--r ../requirements-channels.txt
-
-# Local development requirements
 -r ./requirements.txt
+
+# Channels-specific requirements
+graphql-ws==0.4.4
+channels>=3.0, <3.1

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,8 +1,11 @@
-# Test requirements.
-black==19.3b0
-
-# Your app requirements.
--r ../requirements.txt
-
-# Your app in editable mode.
--e ../
+Django>=2.2,<4.0
+wagtail>=2.11,<2.16
+wagtailmedia
+graphql-core>=2.2.1,<3
+graphene-django>=2.7.1, <2.14.0
+factory-boy==2.12.0
+wagtail-factories==2.0.0
+django-cors-headers==3.4.0
+wagtail-headless-preview==0.1.4
+pre-commit==2.15.0
+wagtail-grapple==0.12.0


### PR DESCRIPTION
- copy actual requirements to example folder instead of depending
   on chaining, the parent path isn't available in the docker build
   context.
- add missing wagtail-grapple requirement in requirements, I used the
   current version in pip, there is probably a better way to require it
   into the docker file.
- include channels requirements

I used this to push https://hub.docker.com/r/dopry/wagtail-grapple-example to meet my needs raised in https://github.com/GrappleGQL/wagtail-grapple/issues/208