### PR TITLE
Support wagtail 2.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        wagtail-version: ['2.11', '2.12', '2.13', '2.14', '2.15']
+        wagtail-version: ['2.11', '2.12', '2.13', '2.14', '2.15', '2.16']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        wagtail-version: ['2.11', '2.12', '2.13', '2.14', '2.15', '2.16']
+        wagtail-version: ['2.14', '2.15', '2.16']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         wagtail-version: ['2.14', '2.15', '2.16']
+        exclude:
+          # exclude python 3.6 from wagtail 2.16 as support dropped.
+          - python-version: '3.6'
+            wagtail-version: '2.16'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         wagtail-version: ['2.14', '2.15', '2.16']
-        exclude:
-          # exclude python 3.6 from wagtail 2.16 as support dropped.
-          - python-version: '3.6'
-            wagtail-version: '2.16'
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Getting Grapple installed is designed to be as simple as possible!
 ### Prerequisites
 
 ```
-Django  >= 2.2
-Wagtail >= 2.11, <2.17
+Django  >= 3.0
+Wagtail >= 2.14, <2.17
 ```
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Getting Grapple installed is designed to be as simple as possible!
 
 ```
 Django  >= 2.2
-Wagtail >= 2.11, <2.16
+Wagtail >= 2.11, <2.17
 ```
 
 ### Installation
@@ -203,7 +203,7 @@ Wagtail Grapple supports:
 
 - Django 2.2.x, 3.0.x, 3.1.x, 3.2.x
 - Python 3.6, 3.7, 3.8, 3.9, and 3.10
-- Wagtail >= 2.11, < 2.16
+- Wagtail >= 2.11, < 2.17
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ Contributions are what make the open source community such an amazing place to b
 
 Wagtail Grapple supports:
 
-- Django 2.2.x, 3.0.x, 3.1.x, 3.2.x
+- Django 3.0.x, 3.1.x, 3.2.x
 - Python 3.6, 3.7, 3.8, 3.9, and 3.10
-- Wagtail >= 2.11, < 2.17
+- Wagtail >= 2.14, < 2.17
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Getting Grapple installed is designed to be as simple as possible!
 ### Prerequisites
 
 ```
-Django  >= 3.0
+Django  >= 3.0, <4.0
 Wagtail >= 2.14, <2.17
 ```
 
@@ -202,7 +202,7 @@ Contributions are what make the open source community such an amazing place to b
 Wagtail Grapple supports:
 
 - Django 3.0.x, 3.1.x, 3.2.x
-- Python 3.6, 3.7, 3.8, 3.9, and 3.10
+- Python 3.7, 3.8, 3.9, and 3.10
 - Wagtail >= 2.14, < 2.17
 
 ## License

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=3.0
-wagtail>=2.11,<2.17
+wagtail>=2.14,<2.17
 wagtailmedia
 graphql-core>=2.2.1,<3
 graphene-django>=2.7.1, <2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=3.0
+Django>=3.0,<4.0
 wagtail>=2.14,<2.17
 wagtailmedia
 graphql-core>=2.2.1,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=2.2
+Django>=3.0
 wagtail>=2.11,<2.17
 wagtailmedia
 graphql-core>=2.2.1,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=2.2
-wagtail>=2.11,<2.16
+wagtail>=2.11,<2.17
 wagtailmedia
 graphql-core>=2.2.1,<3
 graphene-django>=2.7.1, <2.14.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,8 +38,8 @@ setup_requires =
 include_package_data = true
 packages = find:
 install_requires =
-    Django>=2.2
-    wagtail>=2.11, <2.17
+    Django>=3.0
+    wagtail>=2.14, <2.17
     graphene-django>=2.7.1, <2.14.0
     graphql-core>=2.2.1, <3
     wagtail-headless-preview
@@ -47,7 +47,7 @@ install_requires =
 
 [options.extras_require]
 channels =
-    Django>=2.2
+    Django>=3.0
     channels>=3.0, <3.1
     channels_redis==3.3.0
     graphql-ws==0.4.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ include_package_data = true
 packages = find:
 install_requires =
     Django>=2.2
-    wagtail>=2.11, <2.16
+    wagtail>=2.11, <2.17
     graphene-django>=2.7.1, <2.14.0
     graphql-core>=2.2.1, <3
     wagtail-headless-preview

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ keywords =
 classifiers =
   Development Status :: 4 - Beta
   Intended Audience :: Science/Research
-  Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
@@ -31,14 +30,14 @@ license_files =
   LICENSE.txt
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.7
 setup_requires =
   setuptools >= 40.6
   pip >= 10
 include_package_data = true
 packages = find:
 install_requires =
-    Django>=3.0
+    Django>=3.0,<4.0
     wagtail>=2.14, <2.17
     graphene-django>=2.7.1, <2.14.0
     graphql-core>=2.2.1, <3
@@ -47,7 +46,7 @@ install_requires =
 
 [options.extras_require]
 channels =
-    Django>=3.0
+    Django>=3.0,<4.0
     channels>=3.0, <3.1
     channels_redis==3.3.0
     graphql-ws==0.4.4


### PR DESCRIPTION
Wagtail 2.16 is now out, this PR adds support for this new version.

Changes to consider
- Wagtail < 2.14 is dropped as 2.13 is EOL https://endoflife.date/wagtail
- Python < 3.7 is dropped as 3.6 is EOL https://endoflife.date/python
- Django is restricted to version < 4.0 as we can't support it until https://github.com/GrappleGQL/wagtail-grapple/pull/143 is finished and this PR is released https://github.com/graphql-python/graphene-django/pull/1275/files