### PR TITLE
Modify setup.py so package can be detected by GitHub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
 from setuptools import setup
 
-setup()
+# Redefine `name` here so GitHub’s "Used By" can detect the package.
+setup(name="wagtail-grapple")


### PR DESCRIPTION
Inspired by https://patrick.wtf/posts/til-how-to-show-dependents-packages-on-github-when-using-poetry. I tried this on [django-pattern-library](https://github.com/torchbox/django-pattern-library) yesterday (which had no `setup.py` file at all), and it worked.

In the case of Grapple, I assume it’s the name that GitHub will look for – if that assumption is wrong this might need further tweaking. For releases, the rest of the metadata will still come from `setup.cfg` as before (tested by doing a `md5sum` of the `PKG-INFO` before and after the change.