### PR TITLE
Pass instance values to callables

### DIFF
--- a/docs/general-usage/model-types.rst
+++ b/docs/general-usage/model-types.rst
@@ -9,11 +9,39 @@ We created a number of built-in types for general use, but you can create your o
 using `Graphene <https://github.com/graphql-python/graphene/>`_ (Grapple's underlying library)
 and take advantage of Grapple's generic ``GraphQLField`` type.
 
+GraphQLField
+-------------
+.. module:: grapple.models
+.. class:: GraphQLField(field_name: str, field_type: type = None, required=None, **kwargs)
+
+    .. attribute:: field_name (str)
+
+        This is the name of the class property used in your model definition.
+
+    .. attribute:: field_type (type)
+
+        A Grapple model type such as ``GraphQLString`` or ``GraphQLBoolean``.
+
+    .. attribute:: required (bool=None)
+
+        Represents the field as non-nullable in the schema. This promises the client that it will have a value returned.
+
+    .. attribute:: kwargs
+
+        Useful keyword arguments:
+
+        * ``source`` (string)
+            You can pass a source string that is an attribute or method on the
+            class itself. If pointing to a method, all values from the instance
+            will be available within the `values` kwarg (`example <https://github.com/GrappleGQL/wagtail-grapple/blob/main/example/home/blocks.py#L99>`_).
+
+
+
 
 GraphQLString
 -------------
 .. module:: grapple.models
-.. class:: GraphQLString(field_name, required=False)
+.. class:: GraphQLString(field_name, required=False, **kwargs)
 
     A basic field type is string. Commonly used for CharField, TextField,
     UrlField or any other Django field that returns a string as it's value.
@@ -25,6 +53,15 @@ GraphQLString
     .. attribute:: required (bool=False)
 
         Represents the field as non-nullable in the schema. This promises the client that it will have a value returned.
+
+    .. attribute:: kwargs
+
+        Useful keyword arguments:
+
+        * ``source`` (string)
+            You can pass a source string that is an attribute or method on the
+            class itself. If pointing to a method, all values from the instance
+            will be available within the `values` kwarg (`example <https://github.com/GrappleGQL/wagtail-grapple/blob/main/example/home/blocks.py#L99>`_).
 
     In your models.py:
 
@@ -158,7 +195,7 @@ GraphQLCollection
 GraphQLInt
 ----------
 .. module:: grapple.models
-.. class:: GraphQLInt(field_name, required=False)
+.. class:: GraphQLInt(field_name, required=False, **kwargs)
 
     Used to serialize integer-based Django fields such as ``IntegerField``
     or ``PositiveSmallIntegerField``.
@@ -171,11 +208,19 @@ GraphQLInt
 
         Represents the field as non-nullable in the schema. This promises the client that it will have a value returned.
 
+    .. attribute:: kwargs
+
+        Useful keyword arguments:
+
+        * ``source`` (string)
+            You can pass a source string that is an attribute or method on the
+            class itself. If pointing to a method, all values from the instance
+            will be available within the `values` kwarg (`example <https://github.com/GrappleGQL/wagtail-grapple/blob/main/example/home/blocks.py#L99>`_).
 
 GraphQLFloat
 ------------
 .. module:: grapple.models
-.. class:: GraphQLFloat(field_name, required=False)
+.. class:: GraphQLFloat(field_name, required=False, **kwargs)
 
     Like ``GraphQLInt``, this field is used to serialize ``Float`` and ``Decimal`` fields.
 
@@ -187,11 +232,19 @@ GraphQLFloat
 
         Represents the field as non-nullable in the schema. This promises the client that it will have a value returned.
 
+    .. attribute:: kwargs
+
+        Useful keyword arguments:
+
+        * ``source`` (string)
+            You can pass a source string that is an attribute or method on the
+            class itself. If pointing to a method, all values from the instance
+            will be available within the `values` kwarg (`example <https://github.com/GrappleGQL/wagtail-grapple/blob/main/example/home/blocks.py#L99>`_).
 
 GraphQLBoolean
 --------------
 .. module:: grapple.models
-.. class:: GraphQLBoolean(field_name, required=False)
+.. class:: GraphQLBoolean(field_name, required=False, **kwargs)
 
     Used to serialize ``Boolean`` fields.
 
@@ -203,6 +256,14 @@ GraphQLBoolean
 
         Represents the field as non-nullable in the schema. This promises the client that it will have a value returned.
 
+    .. attribute:: kwargs
+
+        Useful keyword arguments:
+
+        * ``source`` (string)
+            You can pass a source string that is an attribute or method on the
+            class itself. If pointing to a method, all values from the instance
+            will be available within the `values` kwarg (`example <https://github.com/GrappleGQL/wagtail-grapple/blob/main/example/home/blocks.py#L99>`_).
 
 GraphQLStreamfield
 ------------------
@@ -466,8 +527,9 @@ GraphQLPage
         * ``required`` (bool=False)
             Represents the field as non-nullable in the schema. This promises the client that it will have a value returned.
         * ``source`` (string)
-            You can pass a source string that is an attribute or method on the model itself. It can also be several
-            layers deep and Grapple will handle the querying for you through multiple models.
+            You can pass a source string that is an attribute or method on the
+            model itself. It can also be several layers deep and Grapple will
+            handle the querying for you through multiple models.
 
 
 GraphQLTag

--- a/docs/general-usage/model-types.rst
+++ b/docs/general-usage/model-types.rst
@@ -51,8 +51,8 @@ GraphQLField
                         )
                     ]
 
-                    def some_method(self, values) -> str:
-                        return values.get("text")
+                    def some_method(self, values: Dict[str, Any] = None) -> Optional[str]:
+                        return values.get("text") if values else None
 
 
 GraphQLString
@@ -94,8 +94,8 @@ GraphQLString
                         )
                     ]
 
-                    def some_method(self, values) -> str:
-                        return values.get("text")
+                    def some_method(self, values: Dict[str, Any] = None) -> Optional[str]:
+                        return values.get("text") if values else None
 
     In your models.py:
 
@@ -264,8 +264,8 @@ GraphQLInt
                         )
                     ]
 
-                    def some_method(self, values) -> int:
-                        return values.get("integer")
+                    def some_method(self, values: Dict[str, Any] = None) -> Optional[int]:
+                        return values.get("integer") if values else None
 
 
 GraphQLFloat
@@ -306,8 +306,8 @@ GraphQLFloat
                         )
                     ]
 
-                    def some_method(self, values) -> float:
-                        return values.get("float")
+                    def some_method(self, values: Dict[str, Any] = None) -> Optional[float]:
+                        return values.get("float") if values else None
 
 
 GraphQLBoolean
@@ -348,8 +348,8 @@ GraphQLBoolean
                         )
                     ]
 
-                    def some_method(self, values) -> bool:
-                        return bool(values.get("text"))
+                    def some_method(self, values: Dict[str, Any] = None) -> Optional[bool]:
+                        return bool(values.get("text")) if values else None
 
 
 GraphQLStreamfield

--- a/docs/general-usage/model-types.rst
+++ b/docs/general-usage/model-types.rst
@@ -307,7 +307,7 @@ GraphQLFloat
                     ]
 
                     def some_method(self, values: Dict[str, Any] = None) -> Optional[float]:
-                        return values.get("float") if values else None
+                        return values.get("decimal") if values else None
 
 
 GraphQLBoolean

--- a/docs/general-usage/model-types.rst
+++ b/docs/general-usage/model-types.rst
@@ -9,6 +9,7 @@ We created a number of built-in types for general use, but you can create your o
 using `Graphene <https://github.com/graphql-python/graphene/>`_ (Grapple's underlying library)
 and take advantage of Grapple's generic ``GraphQLField`` type.
 
+
 GraphQLField
 -------------
 .. module:: grapple.models
@@ -32,10 +33,26 @@ GraphQLField
 
         * ``source`` (string)
             You can pass a source string that is an attribute or method on the
-            class itself. If pointing to a method, all values from the instance
-            will be available within the `values` kwarg (`example <https://github.com/GrappleGQL/wagtail-grapple/blob/main/example/home/blocks.py#L99>`_).
+            class itself.
 
+            If used within a `StreamField`, the method will receive all values
+            from the instance via the `values` kwarg, e.g.:
 
+            .. code-block:: python
+
+                class SomeStructBlock(blocks.StructBlock):
+                    text = blocks.CharBlock()
+
+                    graphql_fields = [
+                        GraphQLField(
+                            field_name="some_name",
+                            field_type=graphene.String,
+                            source="some_method",
+                        )
+                    ]
+
+                    def some_method(self, values) -> str:
+                        return values.get("text")
 
 
 GraphQLString
@@ -60,8 +77,25 @@ GraphQLString
 
         * ``source`` (string)
             You can pass a source string that is an attribute or method on the
-            class itself. If pointing to a method, all values from the instance
-            will be available within the `values` kwarg (`example <https://github.com/GrappleGQL/wagtail-grapple/blob/main/example/home/blocks.py#L99>`_).
+            class itself.
+
+            If used within a `StreamField`, the method will receive all values
+            from the instance via the `values` kwarg, e.g.:
+
+            .. code-block:: python
+
+                class SomeStructBlock(blocks.StructBlock):
+                    text = blocks.CharBlock()
+
+                    graphql_fields = [
+                        GraphQLString(
+                            field_name="some_name",
+                            source="some_method",
+                        )
+                    ]
+
+                    def some_method(self, values) -> str:
+                        return values.get("text")
 
     In your models.py:
 
@@ -163,7 +197,6 @@ GraphQLCollection
                 ),
             ]
 
-
     Example query:
 
     .. code-block:: graphql
@@ -214,8 +247,26 @@ GraphQLInt
 
         * ``source`` (string)
             You can pass a source string that is an attribute or method on the
-            class itself. If pointing to a method, all values from the instance
-            will be available within the `values` kwarg (`example <https://github.com/GrappleGQL/wagtail-grapple/blob/main/example/home/blocks.py#L99>`_).
+            class itself.
+
+            If used within a `StreamField`, the method will receive all values
+            from the instance via the `values` kwarg, e.g.:
+
+            .. code-block:: python
+
+                class SomeStructBlock(blocks.StructBlock):
+                    integer = blocks.IntegerBlock()
+
+                    graphql_fields = [
+                        GraphQLInt(
+                            field_name="some_name",
+                            source="some_method",
+                        )
+                    ]
+
+                    def some_method(self, values) -> int:
+                        return values.get("integer")
+
 
 GraphQLFloat
 ------------
@@ -238,8 +289,26 @@ GraphQLFloat
 
         * ``source`` (string)
             You can pass a source string that is an attribute or method on the
-            class itself. If pointing to a method, all values from the instance
-            will be available within the `values` kwarg (`example <https://github.com/GrappleGQL/wagtail-grapple/blob/main/example/home/blocks.py#L99>`_).
+            class itself.
+
+            If used within a `StreamField`, the method will receive all values
+            from the instance via the `values` kwarg, e.g.:
+
+            .. code-block:: python
+
+                class SomeStructBlock(blocks.StructBlock):
+                    float = blocks.FloatBlock()
+
+                    graphql_fields = [
+                        GraphQLFloat(
+                            field_name="some_name",
+                            source="some_method",
+                        )
+                    ]
+
+                    def some_method(self, values) -> float:
+                        return values.get("float")
+
 
 GraphQLBoolean
 --------------
@@ -262,8 +331,26 @@ GraphQLBoolean
 
         * ``source`` (string)
             You can pass a source string that is an attribute or method on the
-            class itself. If pointing to a method, all values from the instance
-            will be available within the `values` kwarg (`example <https://github.com/GrappleGQL/wagtail-grapple/blob/main/example/home/blocks.py#L99>`_).
+            class itself.
+
+            If used within a `StreamField`, the method will receive all values
+            from the instance via the `values` kwarg, e.g.:
+
+            .. code-block:: python
+
+                class SomeStructBlock(blocks.StructBlock):
+                    text = blocks.CharBlock()
+
+                    graphql_fields = [
+                        GraphQLBoolean(
+                            field_name="some_name",
+                            source="some_method",
+                        )
+                    ]
+
+                    def some_method(self, values) -> bool:
+                        return bool(values.get("text"))
+
 
 GraphQLStreamfield
 ------------------
@@ -350,6 +437,7 @@ GraphQLStreamfield
                 }
             }
         }
+
 
 GraphQLSnippet
 --------------

--- a/example/home/blocks.py
+++ b/example/home/blocks.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, Optional
+
 import graphene
 from django.utils.text import slugify
 from wagtail.core import blocks
@@ -99,12 +101,12 @@ class TextAndButtonsBlock(blocks.StructBlock):
 class TextWithCallableBlock(blocks.StructBlock):
     text = blocks.CharBlock()
     integer = blocks.IntegerBlock()
-    float = blocks.FloatBlock()
+    decimal = blocks.FloatBlock()
 
     graphql_fields = [
         GraphQLString("text"),
         GraphQLInt("integer"),
-        GraphQLFloat("float"),
+        GraphQLFloat("decimal"),
         # GraphQLString test attributes
         GraphQLString("simple_string"),
         GraphQLString("simple_string_method", source="get_simple_string_method"),
@@ -128,12 +130,18 @@ class TextWithCallableBlock(blocks.StructBlock):
     def simple_string(self) -> str:
         return "A simple string property."
 
-    def simple_string_method(self, values):
+    def simple_string_method(
+        self,
+        values: Dict[str, Any] = None,
+    ):
         # Should not be used as we define `source="get_simple_string_method"`.
         raise Exception
 
-    def get_simple_string_method(self, values) -> str:
-        return slugify(values.get("text"))
+    def get_simple_string_method(
+        self,
+        values: Dict[str, Any] = None,
+    ) -> Optional[str]:
+        return slugify(values.get("text")) if values else None
 
     # GraphQLInt test attributes
 
@@ -141,12 +149,18 @@ class TextWithCallableBlock(blocks.StructBlock):
     def simple_int(self) -> int:
         return 5
 
-    def simple_int_method(self, values):
+    def simple_int_method(
+        self,
+        values: Dict[str, Any] = None,
+    ):
         # Should not be used as we define `source="get_simple_int_method"`.
         raise Exception
 
-    def get_simple_int_method(self, values) -> int:
-        return values.get("integer") * 2
+    def get_simple_int_method(
+        self,
+        values: Dict[str, Any] = None,
+    ) -> Optional[int]:
+        return values.get("integer") * 2 if values else None
 
     # GraphQLFloat test attributes
 
@@ -154,12 +168,18 @@ class TextWithCallableBlock(blocks.StructBlock):
     def simple_float(self) -> float:
         return 0.1
 
-    def simple_float_method(self, values):
+    def simple_float_method(
+        self,
+        values: Dict[str, Any] = None,
+    ):
         # Should not be used as we define `source="get_simple_float_method"`.
         raise Exception
 
-    def get_simple_float_method(self, values) -> float:
-        return values.get("float") * 2
+    def get_simple_float_method(
+        self,
+        values: Dict[str, Any] = None,
+    ) -> Optional[float]:
+        return values.get("decimal") * 2 if values else None
 
     # GraphQLBoolean test attributes
 
@@ -167,12 +187,18 @@ class TextWithCallableBlock(blocks.StructBlock):
     def simple_boolean(self) -> bool:
         return 1
 
-    def simple_boolean_method(self, values):
+    def simple_boolean_method(
+        self,
+        values: Dict[str, Any] = None,
+    ):
         # Should not be used as we define `source="get_simple_boolean_method"`.
         raise Exception
 
-    def get_simple_boolean_method(self, values) -> bool:
-        return bool(values.get("text"))
+    def get_simple_boolean_method(
+        self,
+        values: Dict[str, Any] = None,
+    ) -> Optional[bool]:
+        return bool(values.get("text")) if values else None
 
     # GraphQLField test attributes
 
@@ -180,12 +206,18 @@ class TextWithCallableBlock(blocks.StructBlock):
     def get_field_property(self) -> str:
         return "A field property."
 
-    def field_method(self, values):
+    def field_method(
+        self,
+        values: Dict[str, Any] = None,
+    ):
         # Should not be used as we define `source="get_field_method"`.
         raise Exception
 
-    def get_field_method(self, values) -> str:
-        return slugify(values.get("text"))
+    def get_field_method(
+        self,
+        values: Dict[str, Any] = None,
+    ) -> Optional[str]:
+        return slugify(values.get("text")) if values else None
 
 
 class StreamFieldBlock(blocks.StreamBlock):

--- a/example/home/blocks.py
+++ b/example/home/blocks.py
@@ -1,4 +1,5 @@
 import graphene
+from django.utils.text import slugify
 from wagtail.core import blocks
 from wagtail.embeds.blocks import EmbedBlock
 from wagtail.images.blocks import ImageChooserBlock
@@ -104,22 +105,22 @@ class TextWithCallableBlock(blocks.StructBlock):
     ]
 
     @property
-    def simple_string(self, *args, **kwargs):
+    def simple_string(self):
         return "A simple string property."
 
-    def simple_string_method(self, *args, **kwargs):
+    def simple_string_method(self, values):
         # Should not be used as we define `source="get_simple_string_method"`.
         raise Exception
 
-    def get_simple_string_method(self, *args, **kwargs):
-        return "A simple string method."
+    def get_simple_string_method(self, values):
+        return slugify(values.get("text"))
 
     @property
-    def get_field_property(self, *args, **kwargs):
+    def get_field_property(self):
         return "A field property."
 
-    def get_field_method(self, *args, **kwargs):
-        return "A field method."
+    def get_field_method(self, values):
+        return slugify(values.get("text"))
 
 
 class StreamFieldBlock(blocks.StreamBlock):

--- a/example/home/blocks.py
+++ b/example/home/blocks.py
@@ -6,11 +6,14 @@ from wagtail.images.blocks import ImageChooserBlock
 
 from grapple.helpers import register_streamfield_block
 from grapple.models import (
+    GraphQLBoolean,
     GraphQLCollection,
     GraphQLEmbed,
     GraphQLField,
+    GraphQLFloat,
     GraphQLForeignKey,
     GraphQLImage,
+    GraphQLInt,
     GraphQLStreamfield,
     GraphQLString,
 )
@@ -95,31 +98,93 @@ class TextAndButtonsBlock(blocks.StructBlock):
 @register_streamfield_block
 class TextWithCallableBlock(blocks.StructBlock):
     text = blocks.CharBlock()
+    integer = blocks.IntegerBlock()
+    float = blocks.FloatBlock()
 
     graphql_fields = [
         GraphQLString("text"),
+        GraphQLInt("integer"),
+        GraphQLFloat("float"),
+        # GraphQLString test attributes
         GraphQLString("simple_string"),
         GraphQLString("simple_string_method", source="get_simple_string_method"),
+        # GraphQLInt test attributes
+        GraphQLInt("simple_int"),
+        GraphQLInt("simple_int_method", source="get_simple_int_method"),
+        # GraphQLFloat test attributes
+        GraphQLFloat("simple_float"),
+        GraphQLFloat("simple_float_method", source="get_simple_float_method"),
+        # GraphQLBoolean test attributes
+        GraphQLBoolean("simple_boolean"),
+        GraphQLBoolean("simple_boolean_method", source="get_simple_boolean_method"),
+        # GraphQLField test attributes
         GraphQLField("field_property", graphene.String, source="get_field_property"),
         GraphQLField("field_method", graphene.String, source="get_field_method"),
     ]
 
+    # GraphQLString test attributes
+
     @property
-    def simple_string(self):
+    def simple_string(self) -> str:
         return "A simple string property."
 
     def simple_string_method(self, values):
         # Should not be used as we define `source="get_simple_string_method"`.
         raise Exception
 
-    def get_simple_string_method(self, values):
+    def get_simple_string_method(self, values) -> str:
         return slugify(values.get("text"))
 
+    # GraphQLInt test attributes
+
     @property
-    def get_field_property(self):
+    def simple_int(self) -> int:
+        return 5
+
+    def simple_int_method(self, values):
+        # Should not be used as we define `source="get_simple_int_method"`.
+        raise Exception
+
+    def get_simple_int_method(self, values) -> int:
+        return values.get("integer") * 2
+
+    # GraphQLFloat test attributes
+
+    @property
+    def simple_float(self) -> float:
+        return 0.1
+
+    def simple_float_method(self, values):
+        # Should not be used as we define `source="get_simple_float_method"`.
+        raise Exception
+
+    def get_simple_float_method(self, values) -> float:
+        return values.get("float") * 2
+
+    # GraphQLBoolean test attributes
+
+    @property
+    def simple_boolean(self) -> bool:
+        return 1
+
+    def simple_boolean_method(self, values):
+        # Should not be used as we define `source="get_simple_boolean_method"`.
+        raise Exception
+
+    def get_simple_boolean_method(self, values) -> bool:
+        return bool(values.get("text"))
+
+    # GraphQLField test attributes
+
+    @property
+    def get_field_property(self) -> str:
         return "A field property."
 
-    def get_field_method(self, values):
+    def field_method(self, values):
+        # Should not be used as we define `source="get_field_method"`.
+        raise Exception
+
+    def get_field_method(self, values) -> str:
         return slugify(values.get("text"))
 
 

--- a/example/home/factories.py
+++ b/example/home/factories.py
@@ -74,6 +74,8 @@ class ImageGalleryBlockFactory(wagtail_factories.StructBlockFactory):
 
 class TextWithCallableBlockFactory(wagtail_factories.StructBlockFactory):
     text = factory.Sequence(lambda n: f"Text with callable {n}")
+    integer = factory.fuzzy.FuzzyInteger(low=1, high=10)
+    float = factory.fuzzy.FuzzyFloat(low=0.1, high=0.9)
 
     class Meta:
         model = TextWithCallableBlock

--- a/example/home/factories.py
+++ b/example/home/factories.py
@@ -75,7 +75,7 @@ class ImageGalleryBlockFactory(wagtail_factories.StructBlockFactory):
 class TextWithCallableBlockFactory(wagtail_factories.StructBlockFactory):
     text = factory.Sequence(lambda n: f"Text with callable {n}")
     integer = factory.fuzzy.FuzzyInteger(low=1, high=10)
-    float = factory.fuzzy.FuzzyFloat(low=0.1, high=0.9)
+    decimal = factory.fuzzy.FuzzyFloat(low=0.1, high=0.9)
 
     class Meta:
         model = TextWithCallableBlock

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -719,7 +719,85 @@ class BlogTest(BaseGrappleTest):
                 result = query_blocks[0]["simpleStringMethod"]
 
                 # Ensure TextWithCallableBlock.get_simple_string_method called.
+                self.assertIsInstance(result, str)
                 self.assertIn("text-with-callable", result)
+
+    def test_graphqlint_property_in_structblock(self):
+        # Query stream block
+        block_type = "TextWithCallableBlock"
+        query_blocks = self.get_blocks_from_body(block_type, block_query="simpleInt")
+
+        for block in self.blog_page.body:
+            if type(block.block).__name__ == block_type:
+                result = query_blocks[0]["simpleInt"]
+                self.assertEquals(5, result)
+
+    def test_graphqlint_method_in_structblock(self):
+        # Query stream block
+        block_type = "TextWithCallableBlock"
+        query_blocks = self.get_blocks_from_body(
+            block_type, block_query="simpleIntMethod"
+        )
+
+        for block in self.blog_page.body:
+            if type(block.block).__name__ == block_type:
+                # Ensure TextWithCallableBlock.simple_int_method not called.
+                result = query_blocks[0]["simpleIntMethod"]
+
+                # Ensure TextWithCallableBlock.get_simple_int_method called.
+                self.assertIsInstance(result, int)
+
+    def test_graphqlfloat_property_in_structblock(self):
+        # Query stream block
+        block_type = "TextWithCallableBlock"
+        query_blocks = self.get_blocks_from_body(block_type, block_query="simpleFloat")
+
+        for block in self.blog_page.body:
+            if type(block.block).__name__ == block_type:
+                result = query_blocks[0]["simpleFloat"]
+                self.assertEquals(0.1, result)
+
+    def test_graphqlfloat_method_in_structblock(self):
+        # Query stream block
+        block_type = "TextWithCallableBlock"
+        query_blocks = self.get_blocks_from_body(
+            block_type, block_query="simpleFloatMethod"
+        )
+
+        for block in self.blog_page.body:
+            if type(block.block).__name__ == block_type:
+                # Ensure TextWithCallableBlock.simple_float_method not called.
+                result = query_blocks[0]["simpleFloatMethod"]
+
+                # Ensure TextWithCallableBlock.get_simple_float_method called.
+                self.assertIsInstance(result, float)
+
+    def test_graphqlboolean_property_in_structblock(self):
+        # Query stream block
+        block_type = "TextWithCallableBlock"
+        query_blocks = self.get_blocks_from_body(
+            block_type, block_query="simpleBoolean"
+        )
+
+        for block in self.blog_page.body:
+            if type(block.block).__name__ == block_type:
+                result = query_blocks[0]["simpleBoolean"]
+                self.assertEquals(1, result)
+
+    def test_graphqlboolean_method_in_structblock(self):
+        # Query stream block
+        block_type = "TextWithCallableBlock"
+        query_blocks = self.get_blocks_from_body(
+            block_type, block_query="simpleBooleanMethod"
+        )
+
+        for block in self.blog_page.body:
+            if type(block.block).__name__ == block_type:
+                # Ensure TextWithCallableBlock.simple_boolean_method not called.
+                result = query_blocks[0]["simpleBooleanMethod"]
+
+                # Ensure TextWithCallableBlock.get_simple_boolean_method called.
+                self.assertIsInstance(result, bool)
 
     def test_graphqlfield_property_in_structblock(self):
         # Query stream block
@@ -740,5 +818,8 @@ class BlogTest(BaseGrappleTest):
 
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
+                # Ensure TextWithCallableBlock.field_method not called.
                 result = query_blocks[0]["fieldMethod"]
+
+                # Ensure TextWithCallableBlock.get_field_method called.
                 self.assertIn("text-with-callable", result)

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -719,7 +719,7 @@ class BlogTest(BaseGrappleTest):
                 result = query_blocks[0]["simpleStringMethod"]
 
                 # Ensure TextWithCallableBlock.get_simple_string_method called.
-                self.assertEquals("A simple string method.", result)
+                self.assertIn("text-with-callable", result)
 
     def test_graphqlfield_property_in_structblock(self):
         # Query stream block
@@ -741,4 +741,4 @@ class BlogTest(BaseGrappleTest):
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
                 result = query_blocks[0]["fieldMethod"]
-                self.assertEquals("A field method.", result)
+                self.assertIn("text-with-callable", result)

--- a/example/home/test/test_blog.py
+++ b/example/home/test/test_blog.py
@@ -225,7 +225,6 @@ class BlogTest(BaseGrappleTest):
         self.assertEquals(len(query_blocks), count)
 
     def test_blog_body_imagechooserblock_in_streamblock(self):
-        # Query stream block
         block_type = "CarouselBlock"
         query_blocks = self.get_blocks_from_body(
             block_type,
@@ -252,7 +251,6 @@ class BlogTest(BaseGrappleTest):
             self.fail(f"{url} is not a valid url")
 
     def test_blog_body_calloutblock(self):
-        # Query stream block
         block_type = "CalloutBlock"
         query_blocks = self.get_blocks_from_body(
             block_type,
@@ -580,7 +578,6 @@ class BlogTest(BaseGrappleTest):
         self.assertEquals(pagination["totalPages"], 2)
 
     def test_structvalue_block(self):
-        # Query stream block
         block_type = "TextAndButtonsBlock"
         query_blocks = self.get_blocks_from_body(
             block_type,
@@ -602,7 +599,6 @@ class BlogTest(BaseGrappleTest):
                 self.assertEquals(buttons[0]["buttonLink"], "https://www.graphql.com/")
 
     def test_nested_structvalue_block(self):
-        # Query stream block
         block_type = "TextAndButtonsBlock"
         query_blocks = self.get_blocks_from_body(
             block_type,
@@ -697,129 +693,117 @@ class BlogTest(BaseGrappleTest):
             self.assertEqual(tag["name"], "Tag " + str(idx))
 
     def test_graphqlstring_property_in_structblock(self):
-        # Query stream block
         block_type = "TextWithCallableBlock"
-        query_blocks = self.get_blocks_from_body(block_type, block_query="simpleString")
+        block_query = "simpleString"
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
 
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
-                result = query_blocks[0]["simpleString"]
+                result = query_blocks[0][block_query]
                 self.assertEquals("A simple string property.", result)
 
     def test_graphqlstring_method_in_structblock(self):
-        # Query stream block
         block_type = "TextWithCallableBlock"
-        query_blocks = self.get_blocks_from_body(
-            block_type, block_query="simpleStringMethod"
-        )
+        block_query = "simpleStringMethod"
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
 
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
                 # Ensure TextWithCallableBlock.simple_string_method not called.
-                result = query_blocks[0]["simpleStringMethod"]
+                result = query_blocks[0][block_query]
 
                 # Ensure TextWithCallableBlock.get_simple_string_method called.
                 self.assertIsInstance(result, str)
                 self.assertIn("text-with-callable", result)
 
     def test_graphqlint_property_in_structblock(self):
-        # Query stream block
         block_type = "TextWithCallableBlock"
-        query_blocks = self.get_blocks_from_body(block_type, block_query="simpleInt")
+        block_query = "simpleInt"
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
 
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
-                result = query_blocks[0]["simpleInt"]
+                result = query_blocks[0][block_query]
                 self.assertEquals(5, result)
 
     def test_graphqlint_method_in_structblock(self):
-        # Query stream block
         block_type = "TextWithCallableBlock"
-        query_blocks = self.get_blocks_from_body(
-            block_type, block_query="simpleIntMethod"
-        )
+        block_query = "simpleIntMethod"
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
 
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
                 # Ensure TextWithCallableBlock.simple_int_method not called.
-                result = query_blocks[0]["simpleIntMethod"]
+                result = query_blocks[0][block_query]
 
                 # Ensure TextWithCallableBlock.get_simple_int_method called.
                 self.assertIsInstance(result, int)
 
     def test_graphqlfloat_property_in_structblock(self):
-        # Query stream block
         block_type = "TextWithCallableBlock"
-        query_blocks = self.get_blocks_from_body(block_type, block_query="simpleFloat")
+        block_query = "simpleFloat"
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
 
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
-                result = query_blocks[0]["simpleFloat"]
+                result = query_blocks[0][block_query]
                 self.assertEquals(0.1, result)
 
     def test_graphqlfloat_method_in_structblock(self):
-        # Query stream block
         block_type = "TextWithCallableBlock"
-        query_blocks = self.get_blocks_from_body(
-            block_type, block_query="simpleFloatMethod"
-        )
+        block_query = "simpleFloatMethod"
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
 
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
                 # Ensure TextWithCallableBlock.simple_float_method not called.
-                result = query_blocks[0]["simpleFloatMethod"]
+                result = query_blocks[0][block_query]
 
                 # Ensure TextWithCallableBlock.get_simple_float_method called.
                 self.assertIsInstance(result, float)
 
     def test_graphqlboolean_property_in_structblock(self):
-        # Query stream block
         block_type = "TextWithCallableBlock"
-        query_blocks = self.get_blocks_from_body(
-            block_type, block_query="simpleBoolean"
-        )
+        block_query = "simpleBoolean"
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
 
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
-                result = query_blocks[0]["simpleBoolean"]
+                result = query_blocks[0][block_query]
                 self.assertEquals(1, result)
 
     def test_graphqlboolean_method_in_structblock(self):
-        # Query stream block
         block_type = "TextWithCallableBlock"
-        query_blocks = self.get_blocks_from_body(
-            block_type, block_query="simpleBooleanMethod"
-        )
+        block_query = "simpleBooleanMethod"
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
 
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
                 # Ensure TextWithCallableBlock.simple_boolean_method not called.
-                result = query_blocks[0]["simpleBooleanMethod"]
+                result = query_blocks[0][block_query]
 
                 # Ensure TextWithCallableBlock.get_simple_boolean_method called.
                 self.assertIsInstance(result, bool)
 
     def test_graphqlfield_property_in_structblock(self):
-        # Query stream block
         block_type = "TextWithCallableBlock"
-        query_blocks = self.get_blocks_from_body(
-            block_type, block_query="fieldProperty"
-        )
+        block_query = "fieldProperty"
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
 
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
-                result = query_blocks[0]["fieldProperty"]
+                result = query_blocks[0][block_query]
                 self.assertEquals("A field property.", result)
 
     def test_graphqlfield_method_in_structblock(self):
-        # Query stream block
         block_type = "TextWithCallableBlock"
-        query_blocks = self.get_blocks_from_body(block_type, block_query="fieldMethod")
+        block_query = "fieldMethod"
+        query_blocks = self.get_blocks_from_body(block_type, block_query=block_query)
 
         for block in self.blog_page.body:
             if type(block.block).__name__ == block_type:
                 # Ensure TextWithCallableBlock.field_method not called.
-                result = query_blocks[0]["fieldMethod"]
+                result = query_blocks[0][block_query]
 
                 # Ensure TextWithCallableBlock.get_field_method called.
                 self.assertIn("text-with-callable", result)

--- a/grapple/models.py
+++ b/grapple/models.py
@@ -11,7 +11,7 @@ class GraphQLField:
     field_source: str
 
     def __init__(
-        self, field_name: str, field_type: type = None, required=None, **kwargs
+        self, field_name: str, field_type: type = None, required: bool = None, **kwargs
     ):
         # Initiate and get specific field info.
         self.field_name = field_name


### PR DESCRIPTION
Although [callables are now supported](https://github.com/GrappleGQL/wagtail-grapple/pull/220), you still cannot use any data held within the instance, which is arguably the main reason for wanting to use a callable.

This MR addresses that and passes all values for an instance to the callable method within a `StructBlock`. It also tidies a few things up.