### PR TITLE
Feature/plural query fields

### DIFF
--- a/example/home/test/test_advert.py
+++ b/example/home/test/test_advert.py
@@ -31,6 +31,22 @@ class AdvertTest(BaseGrappleTest):
         # Check all the fields
         self.validate_advert(advert)
 
+    def test_advert_all_query_fields(self):
+        query = """
+        query($url: String) {
+            adverts(url: $url) {
+                id
+                url
+                text
+            }
+        }
+        """
+        executed = self.client.execute(query, variables={"url": self.advert.url})
+        advert = executed["data"]["adverts"][0]
+
+        # Check all the fields
+        self.validate_advert(advert)
+
     def test_advert_single_query(self):
         query = """
         query($url: String) {

--- a/grapple/helpers.py
+++ b/grapple/helpers.py
@@ -141,7 +141,9 @@ def register_query_field(
             setattr(
                 schema,
                 plural_field_name,
-                QuerySetList(plural_field_type, required=plural_required),
+                QuerySetList(
+                    plural_field_type, required=plural_required, **field_query_params
+                ),
             )
 
             setattr(

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -268,12 +268,12 @@ def PagesQuery():
         )
 
         # Return all pages in site, ideally specific.
-        def resolve_pages(self, info, **kwargs):
+        def resolve_pages(self, info, in_site=False, **kwargs):
             pages = (
                 WagtailPage.objects.live().public().filter(depth__gt=1).specific()
             )  # no need to the root page
 
-            if kwargs.get("in_site", False):
+            if in_site:
                 site = Site.find_for_request(info.context)
                 pages = pages.in_site(site)
 

--- a/grapple/types/pages.py
+++ b/grapple/types/pages.py
@@ -268,7 +268,7 @@ def PagesQuery():
         )
 
         # Return all pages in site, ideally specific.
-        def resolve_pages(self, info, in_site=False, **kwargs):
+        def resolve_pages(self, info, *, in_site=False, content_type=None, **kwargs):
             pages = (
                 WagtailPage.objects.live().public().filter(depth__gt=1).specific()
             )  # no need to the root page
@@ -277,7 +277,6 @@ def PagesQuery():
                 site = Site.find_for_request(info.context)
                 pages = pages.in_site(site)
 
-            content_type = kwargs.pop("content_type", None)
             if content_type:
                 app_label, model = content_type.strip().lower().split(".")
                 try:

--- a/grapple/utils.py
+++ b/grapple/utils.py
@@ -58,10 +58,10 @@ def resolve_queryset(
     :type collection: int
     """
 
+    if kwargs:
+        qs = qs.filter(**kwargs)
     if id is not None:
         qs = qs.filter(pk=id)
-    else:
-        qs = qs.all()
 
     if id is None and search_query:
         # Check if the queryset is searchable using Wagtail search.


### PR DESCRIPTION
Applies the query_params to the plural field as well.

A more ideal solution might be to separate out the singular and plural query helpers, as some query params might not be appropriate for both queries.

The main 'bug fix' for this is to use the kwargs in `resolve_queryset()` to enable custom filtering. In order to make this work, I needed to remove `in_site` from kwargs by setting them as a keyword argument on `resolve_pages()`, where that flag is actually used. Even if you don't want to alter the API behaviour of `register_query_field()`, this functionality makes it possible to create the separate helpers, as I mentioned above.